### PR TITLE
feat: Make It Exciting - Tropico-grade overhaul (Phases 1+2+3) + production hotfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "framer-motion": "^12.38.0",
         "lucide-react": "^1.7.0",
-        "react": "^19.2.4",
-        "react-dom": "^19.2.4"
+        "react": "19.2.5",
+        "react-dom": "19.2.5"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "dependencies": {
     "framer-motion": "^12.38.0",
     "lucide-react": "^1.7.0",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react": "19.2.5",
+    "react-dom": "19.2.5"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,11 +3,13 @@ import { GameState, GameEvent } from './engine/types';
 import { createInitialState } from './engine/state';
 import { startTurn, resolveTurn } from './engine/turn';
 import { applyBudgetAllocationEffects, applyIndicatorOverrides } from './engine/startAdjustments';
+import { applyTraitStartBias, type TraitId } from './engine/traits';
 import { ALL_EVENTS } from './data';
 import { generateAIEvent, evaluateCustomChoice, getAvailableModels, type AIModel } from './engine/ai';
 import { saveAiEvent, pickSavedEvent } from './engine/savedEvents';
 import { fetchDynamicStartData, fetchHistoricalData, type HistoricalScenario, HISTORICAL_SCENARIOS } from './engine/latviaData';
 import TitleScreen from './ui/TitleScreen';
+import OnboardingScreen from './ui/OnboardingScreen';
 import GameScreen from './ui/GameScreen';
 import GameOverScreen from './ui/GameOverScreen';
 import QuizScreen from './ui/QuizScreen';
@@ -15,13 +17,14 @@ import BudgetScreen from './ui/BudgetScreen';
 import RealityDashboard from './ui/RealityDashboard';
 import ElectionResultsScreen from './ui/ElectionResultsScreen';
 
-type Screen = 'title' | 'game' | 'gameover' | 'quiz' | 'budget' | 'reality' | 'election';
+type Screen = 'title' | 'onboarding' | 'game' | 'gameover' | 'quiz' | 'budget' | 'reality' | 'election';
 
 // Screens that can be navigated to via URL hash
 const HASH_SCREENS: Record<string, Screen> = {
   '#quiz': 'quiz',
   '#reality': 'reality',
   '#game': 'game',
+  '#onboarding': 'onboarding',
 };
 
 function getScreenFromHash(): Screen {
@@ -122,8 +125,20 @@ export default function App() {
     }
 
     setPendingState(state);
-    setScreen('budget');
+    setScreen('onboarding');
   }, []);
+
+  const handleTraitsConfirm = useCallback((traits: TraitId[]) => {
+    const state = pendingState;
+    if (!state) return;
+    const biased = {
+      ...state,
+      traits,
+      indicators: applyTraitStartBias(state.indicators, traits),
+    };
+    setPendingState(biased);
+    setScreen('budget');
+  }, [pendingState]);
 
   const handleBudgetAllocate = useCallback(async (allocations: Record<string, number>) => {
     const state = pendingState;
@@ -274,6 +289,12 @@ export default function App() {
         />
       )}
       {screen === 'quiz' && <QuizScreen onBack={handleRestart} />}
+      {screen === 'onboarding' && (
+        <OnboardingScreen
+          onConfirm={handleTraitsConfirm}
+          onBack={() => setScreen('title')}
+        />
+      )}
       {screen === 'budget' && (
         <BudgetScreen onAllocate={handleBudgetAllocate} onSkip={handleBudgetSkip} />
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,12 @@ import { GameState, GameEvent } from './engine/types';
 import { createInitialState } from './engine/state';
 import { startTurn, resolveTurn } from './engine/turn';
 import { applyBudgetAllocationEffects, applyIndicatorOverrides } from './engine/startAdjustments';
+import { INDICATORS } from './engine/indicators';
 import { applyTraitStartBias, type TraitId } from './engine/traits';
 import { applyTraitFactionBias } from './engine/factions';
+import { advancePillar, type PillarId } from './engine/constitution';
+import { resolveDemand } from './engine/superpowers';
+import { enactDecree, revokeDecree } from './engine/decrees';
 import { ALL_EVENTS } from './data';
 import { generateAIEvent, evaluateCustomChoice, getAvailableModels, type AIModel } from './engine/ai';
 import { saveAiEvent, pickSavedEvent } from './engine/savedEvents';
@@ -75,36 +79,34 @@ export default function App() {
     });
   }, []);
 
-  const generateEvents = useCallback(async (state: GameState): Promise<GameEvent[]> => {
-    const { events: staticEvents } = startTurn(state, ALL_EVENTS);
+  const generateEvents = useCallback(async (state: GameState): Promise<{ events: GameEvent[]; nextState: GameState }> => {
+    const { state: nextState, events: staticEvents } = startTurn(state, ALL_EVENTS);
 
     if (!aiMode || aiModels.length === 0) {
-      return staticEvents;
+      return { events: staticEvents, nextState };
     }
 
     // Hybrid: 1 static + 1 AI-generated event
     setAiLoading(true);
     try {
-      // Try saved AI events first (from previous games)
       const recentTitles = state.history
         .slice(-5)
         .flatMap(h => h.events.map(e => e.event.title));
       const saved = pickSavedEvent(state, recentTitles);
       if (saved) {
-        return [staticEvents[0], saved].filter(Boolean);
+        return { events: [staticEvents[0], saved].filter(Boolean), nextState };
       }
 
-      // No suitable saved event — generate a new one via API
       const aiEvent = await generateAIEvent(state, selectedModel);
       if (aiEvent) {
-        return [staticEvents[0], aiEvent as GameEvent].filter(Boolean);
+        return { events: [staticEvents[0], aiEvent as GameEvent].filter(Boolean), nextState };
       }
     } catch {
       // Fallback to all static
     } finally {
       setAiLoading(false);
     }
-    return staticEvents;
+    return { events: staticEvents, nextState };
   }, [aiMode, aiModels, selectedModel]);
 
   const handleStartGame = useCallback(async (scenario?: HistoricalScenario) => {
@@ -168,7 +170,8 @@ export default function App() {
     };
 
     setGameState(nextState);
-    const events = await generateEvents(nextState);
+    const { events, nextState: turnState } = await generateEvents(nextState);
+    setGameState(turnState);
     setCurrentEvents(events);
     setDecisions(new Map());
     setScreen('game');
@@ -179,7 +182,8 @@ export default function App() {
     if (!state) return;
     const nextState = { ...state, indicators: { ...state.indicators } };
     setGameState(nextState);
-    const events = await generateEvents(nextState);
+    const { events, nextState: turnState } = await generateEvents(nextState);
+    setGameState(turnState);
     setCurrentEvents(events);
     setDecisions(new Map());
     setScreen('game');
@@ -269,7 +273,8 @@ export default function App() {
       return;
     }
 
-    const events = await generateEvents(newState);
+    const { events, nextState: turnState } = await generateEvents(newState);
+    setGameState(turnState);
     setCurrentEvents(events);
     setDecisions(new Map());
   }, [gameState, currentEvents, decisions, generateEvents]);
@@ -279,6 +284,85 @@ export default function App() {
     setGameState(null);
     setCurrentEvents([]);
     setDecisions(new Map());
+  }, []);
+
+  const handleAdvancePillar = useCallback((pillar: PillarId, direction: 1 | -1) => {
+    setGameState(prev => {
+      if (!prev) return prev;
+      const { next, step } = advancePillar(prev.constitution, pillar, direction);
+      if (!step) return prev;
+      // Apply step effects to indicators + faction bias
+      const newIndicators = { ...prev.indicators };
+      for (const eff of step.effects) {
+        const meta = INDICATORS.find(i => i.key === eff.indicator);
+        const cur = newIndicators[eff.indicator] ?? 0;
+        const min = meta?.min ?? 0;
+        const max = meta?.max ?? 100;
+        newIndicators[eff.indicator] = Math.min(max, Math.max(min, cur + eff.delta));
+      }
+      const newFaction = step.factionBias
+        ? Object.entries(step.factionBias).reduce((acc, [fid, delta]) => {
+            const cur = acc[fid as keyof typeof acc] ?? 50;
+            acc[fid as keyof typeof acc] = Math.max(0, Math.min(100, cur + delta));
+            return acc;
+          }, { ...prev.factionApproval })
+        : prev.factionApproval;
+      return { ...prev, constitution: next, indicators: newIndicators, factionApproval: newFaction };
+    });
+  }, []);
+
+  const handleResolveDemand = useCallback((demandId: string, optionIdx: number) => {
+    setGameState(prev => {
+      if (!prev) return prev;
+      const { state: nextSp, option } = resolveDemand(prev.superpowers, demandId, optionIdx, prev.turn);
+      if (!option) return prev;
+      // Apply option effects to indicators
+      const newIndicators = { ...prev.indicators };
+      for (const eff of option.effects) {
+        const meta = INDICATORS.find(i => i.key === eff.indicator);
+        const cur = newIndicators[eff.indicator] ?? 0;
+        const min = meta?.min ?? 0;
+        const max = meta?.max ?? 100;
+        newIndicators[eff.indicator] = Math.min(max, Math.max(min, cur + eff.delta));
+      }
+      // Apply faction reactions
+      const newFaction = { ...prev.factionApproval };
+      if (option.factionReactions) {
+        const reactionVal: Record<string, number> = { love: 8, cheer: 4, meh: 0, frown: -4, rage: -8 };
+        for (const [fid, level] of Object.entries(option.factionReactions)) {
+          const k = fid as keyof typeof newFaction;
+          newFaction[k] = Math.max(0, Math.min(100, (newFaction[k] ?? 50) + reactionVal[level]));
+        }
+      }
+      return { ...prev, superpowers: nextSp, indicators: newIndicators, factionApproval: newFaction };
+    });
+  }, []);
+
+  const handleEnactDecree = useCallback((decreeId: string) => {
+    setGameState(prev => {
+      if (!prev) return prev;
+      const { state: next, def } = enactDecree(prev, decreeId);
+      if (!def) return prev;
+      // Apply enact-time faction reactions
+      let factionApproval = prev.factionApproval;
+      if (def.factionReactions) {
+        factionApproval = { ...prev.factionApproval };
+        const reactionVal: Record<string, number> = { love: 8, cheer: 4, meh: 0, frown: -4, rage: -8 };
+        for (const [fid, level] of Object.entries(def.factionReactions)) {
+          const k = fid as keyof typeof factionApproval;
+          factionApproval[k] = Math.max(0, Math.min(100, (factionApproval[k] ?? 50) + reactionVal[level]));
+        }
+      }
+      return { ...next, factionApproval };
+    });
+  }, []);
+
+  const handleRevokeDecree = useCallback((decreeId: string) => {
+    setGameState(prev => {
+      if (!prev) return prev;
+      const { state: next } = revokeDecree(prev, decreeId);
+      return next;
+    });
   }, []);
 
   const handleElectionContinue = useCallback(async () => {
@@ -301,7 +385,8 @@ export default function App() {
     };
     setGameState(finalState);
     setPendingState(null);
-    const events = await generateEvents(finalState);
+    const { events, nextState: turnState } = await generateEvents(finalState);
+    setGameState(turnState);
     setCurrentEvents(events);
     setDecisions(new Map());
     setScreen('game');
@@ -345,6 +430,10 @@ export default function App() {
           decisions={decisions}
           onMakeChoice={handleMakeChoice}
           onEndTurn={handleEndTurn}
+          onAdvancePillar={handleAdvancePillar}
+          onResolveDemand={handleResolveDemand}
+          onEnactDecree={handleEnactDecree}
+          onRevokeDecree={handleRevokeDecree}
           aiMode={aiMode}
           onToggleAI={() => setAiMode(m => !m)}
           aiModels={aiModels}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,14 @@ import { createInitialState } from './engine/state';
 import { startTurn, resolveTurn } from './engine/turn';
 import { applyBudgetAllocationEffects, applyIndicatorOverrides } from './engine/startAdjustments';
 import { applyTraitStartBias, type TraitId } from './engine/traits';
+import { applyTraitFactionBias } from './engine/factions';
 import { ALL_EVENTS } from './data';
 import { generateAIEvent, evaluateCustomChoice, getAvailableModels, type AIModel } from './engine/ai';
 import { saveAiEvent, pickSavedEvent } from './engine/savedEvents';
 import { fetchDynamicStartData, fetchHistoricalData, type HistoricalScenario, HISTORICAL_SCENARIOS } from './engine/latviaData';
 import TitleScreen from './ui/TitleScreen';
 import OnboardingScreen from './ui/OnboardingScreen';
+import ManifestoScreen from './ui/ManifestoScreen';
 import GameScreen from './ui/GameScreen';
 import GameOverScreen from './ui/GameOverScreen';
 import QuizScreen from './ui/QuizScreen';
@@ -17,7 +19,7 @@ import BudgetScreen from './ui/BudgetScreen';
 import RealityDashboard from './ui/RealityDashboard';
 import ElectionResultsScreen from './ui/ElectionResultsScreen';
 
-type Screen = 'title' | 'onboarding' | 'game' | 'gameover' | 'quiz' | 'budget' | 'reality' | 'election';
+type Screen = 'title' | 'onboarding' | 'manifesto' | 'game' | 'gameover' | 'quiz' | 'budget' | 'reality' | 'election';
 
 // Screens that can be navigated to via URL hash
 const HASH_SCREENS: Record<string, Screen> = {
@@ -135,6 +137,22 @@ export default function App() {
       ...state,
       traits,
       indicators: applyTraitStartBias(state.indicators, traits),
+      factionApproval: applyTraitFactionBias(state.factionApproval, traits),
+    };
+    setPendingState(biased);
+    setScreen('manifesto');
+  }, [pendingState]);
+
+  const handleManifestoConfirm = useCallback((promiseIds: string[]) => {
+    const state = pendingState;
+    if (!state) return;
+    const termIndex = state.parliament.electionHistory.length; // 0 for first term
+    const biased = {
+      ...state,
+      promises: [
+        ...state.promises,
+        ...promiseIds.map(id => ({ promiseId: id, termIndex })),
+      ],
     };
     setPendingState(biased);
     setScreen('budget');
@@ -265,14 +283,29 @@ export default function App() {
 
   const handleElectionContinue = useCallback(async () => {
     if (!gameState) return;
-    // Clear election pending flag and continue
+    // Clear election pending flag and route to manifesto for new term
     const updatedState = { ...gameState, electionPending: false, lastElectionResult: undefined };
-    setGameState(updatedState);
-    const events = await generateEvents(updatedState);
+    setPendingState(updatedState);
+    setScreen('manifesto');
+  }, [gameState]);
+
+  const handleNewTermManifestoConfirm = useCallback(async (promiseIds: string[]) => {
+    if (!pendingState) return;
+    const termIndex = pendingState.parliament.electionHistory.length;
+    const finalState = {
+      ...pendingState,
+      promises: [
+        ...pendingState.promises,
+        ...promiseIds.map(id => ({ promiseId: id, termIndex })),
+      ],
+    };
+    setGameState(finalState);
+    setPendingState(null);
+    const events = await generateEvents(finalState);
     setCurrentEvents(events);
     setDecisions(new Map());
     setScreen('game');
-  }, [gameState, generateEvents]);
+  }, [pendingState, generateEvents]);
 
   const handleQuiz = useCallback(() => {
     setScreen('quiz');
@@ -293,6 +326,12 @@ export default function App() {
         <OnboardingScreen
           onConfirm={handleTraitsConfirm}
           onBack={() => setScreen('title')}
+        />
+      )}
+      {screen === 'manifesto' && (
+        <ManifestoScreen
+          onConfirm={gameState ? handleNewTermManifestoConfirm : handleManifestoConfirm}
+          termNumber={(pendingState?.parliament.electionHistory.length ?? 0) + (gameState ? 0 : 1)}
         />
       )}
       {screen === 'budget' && (

--- a/src/data/economy-events.ts
+++ b/src/data/economy-events.ts
@@ -9,6 +9,7 @@ export const economyEvents: GameEvent[] = [
     category: 'economy',
     weight: 8,
     oneTime: true,
+    highStakes: true,
     flavor: 'The Estonians are already designing their station\'s gift shop. Lithuania has started selling tickets. Latvia is still debating the route.',
     choices: [
       {
@@ -22,6 +23,12 @@ export const economyEvents: GameEvent[] = [
           { indicator: 'portActivity', delta: 6, delay: 4, duration: 0 },
         ],
         hasEcho: true,
+        factionReactions: {
+          entrepreneurs: 'cheer',
+          reformBloc: 'love',
+          green: 'frown',
+          identity: 'meh',
+        },
         humor: 'The infrastructure minister starts wearing a conductor\'s hat to cabinet meetings.',
       },
       {
@@ -32,6 +39,11 @@ export const economyEvents: GameEvent[] = [
           { indicator: 'euStanding', delta: -4, delay: 1, duration: 0 },
           { indicator: 'foreignInvestment', delta: -3, delay: 2, duration: 0 },
         ],
+        factionReactions: {
+          entrepreneurs: 'frown',
+          reformBloc: 'rage',
+          identity: 'cheer',
+        },
         humor: 'The train will have a station in Latvia. It just won\'t stop there very often.',
       },
       {
@@ -44,6 +56,13 @@ export const economyEvents: GameEvent[] = [
           { indicator: 'euStanding', delta: 3, delay: 3, duration: 0 },
           { indicator: 'foreignInvestment', delta: 12, delay: 5, duration: 0 },
         ],
+        hasEcho: true,
+        factionReactions: {
+          entrepreneurs: 'love',
+          identity: 'cheer',
+          reformBloc: 'cheer',
+          socialDems: 'frown',
+        },
         humor: 'Latvia: "We meant to put the station in our country." Estonia: "...yes, that\'s how railways work."',
       },
     ],
@@ -57,6 +76,7 @@ export const economyEvents: GameEvent[] = [
     category: 'economy',
     weight: 7,
     oneTime: false,
+    highStakes: true,
     choices: [
       {
         label: 'Return to flat tax',

--- a/src/data/economy-events.ts
+++ b/src/data/economy-events.ts
@@ -57,6 +57,7 @@ export const economyEvents: GameEvent[] = [
           { indicator: 'foreignInvestment', delta: 12, delay: 5, duration: 0 },
         ],
         hasEcho: true,
+        irreversible: true,
         factionReactions: {
           entrepreneurs: 'love',
           identity: 'cheer',

--- a/src/data/economy-events.ts
+++ b/src/data/economy-events.ts
@@ -21,6 +21,7 @@ export const economyEvents: GameEvent[] = [
           { indicator: 'euStanding', delta: 5, delay: 2, duration: 0 },
           { indicator: 'portActivity', delta: 6, delay: 4, duration: 0 },
         ],
+        hasEcho: true,
         humor: 'The infrastructure minister starts wearing a conductor\'s hat to cabinet meetings.',
       },
       {
@@ -67,6 +68,7 @@ export const economyEvents: GameEvent[] = [
           { indicator: 'publicHappiness', delta: -3, delay: 1, duration: 0 },
           { indicator: 'taxBurden', delta: -5, delay: 0, duration: 0 },
         ],
+        hasEcho: true,
         humor: 'Oligarchs in Jūrmala celebrate with champagne. Hospital queues grow slightly longer.',
       },
       {
@@ -80,6 +82,7 @@ export const economyEvents: GameEvent[] = [
           { indicator: 'publicHappiness', delta: 2, delay: 1, duration: 0 },
           { indicator: 'taxBurden', delta: 5, delay: 0, duration: 0 },
         ],
+        hasEcho: true,
         humor: 'A prominent businessman tweets from his new Tallinn office: "Estonia is beautiful this time of year."',
       },
       {

--- a/src/engine/arcs.ts
+++ b/src/engine/arcs.ts
@@ -1,0 +1,596 @@
+import type { GameEvent, GameState } from './types';
+
+/**
+ * Crusader-Kings-style event chain arcs.
+ *
+ * An Arc is a state machine: triggered by a condition, advances through
+ * 3-6 stages over 4-10 turns. Each stage is a GameEvent surfaced normally
+ * via the events pool. Stages have triggers based on what the player chose
+ * in the previous stage.
+ *
+ * Arcs live in their own pool — the engine pulls a stage event when the
+ * arc is "due" and the trigger conditions are met. Arcs are stored on
+ * GameState.activeArcs as { arcId, stage, turnStarted, branch }.
+ */
+
+export type ArcId =
+  | 'railBaltica'
+  | 'rigaHousing'
+  | 'brainDrain'
+  | 'latgale'
+  | 'energyPivot';
+
+export interface ArcStage {
+  /** Stage number — 1-indexed. */
+  number: number;
+  /** Earliest turn after arc start when this stage may fire. */
+  minDelay: number;
+  /** Latest turn after arc start when this stage may fire (deadline). */
+  maxDelay: number;
+  /** Which previous-stage branch(es) lead here. */
+  fromBranches?: string[];
+  /** Build the GameEvent for this stage. Receives current state for context. */
+  build: (s: GameState) => GameEvent;
+}
+
+export interface ArcDef {
+  id: ArcId;
+  title: string;
+  /** Whether this arc may be triggered yet (gating condition). */
+  canTrigger: (s: GameState, currentTurn: number) => boolean;
+  /** Stages in order. */
+  stages: ArcStage[];
+}
+
+export interface ActiveArc {
+  arcId: ArcId;
+  stage: number;
+  turnStarted: number;
+  branch?: string;
+}
+
+// Reserved for future condition-gated arc stages.
+const _UNUSED_ARC_NS = 1;
+
+// ─── Arc 1: Riga Housing Crisis ──────────────────────────────────
+const RIGA_HOUSING: ArcDef = {
+  id: 'rigaHousing',
+  title: 'The Riga Housing Crisis',
+  canTrigger: (s, t) => t >= 4 && s.indicators.foreignInvestment > 50,
+  stages: [
+    {
+      number: 1,
+      minDelay: 0,
+      maxDelay: 1,
+      build: () => ({
+        id: 'arc_rigaHousing_1',
+        title: '🏘️ Rents in Riga Are Out of Hand',
+        description: 'Rents in central Riga have risen 40% in two years. Tech workers cheer the landlord class. Nurses and teachers are moving to Salaspils — or further.',
+        preconditions: [],
+        category: 'society',
+        weight: 100,
+        oneTime: true,
+        highStakes: true,
+        choices: [
+          {
+            label: 'Introduce rent control on properties built before 2000',
+            description: 'A cap on annual rent increases for older stock. Tenants exhale. Landlords lawyer up.',
+            effects: [
+              { indicator: 'socialStrain', delta: -4, delay: 0, duration: 0 },
+              { indicator: 'foreignInvestment', delta: -4, delay: 1, duration: 0 },
+              { indicator: 'publicConfidence', delta: 4, delay: 1, duration: 0 },
+            ],
+            factionReactions: { socialDems: 'cheer', entrepreneurs: 'rage', reformBloc: 'frown' },
+            humor: 'A constitutional law professor is interviewed. She uses the words "interesting" and "litigation" in the same sentence.',
+          },
+          {
+            label: 'Subsidise new construction in Pārdaugava',
+            description: 'Direct grants for developers + faster permits. Supply, eventually.',
+            effects: [
+              { indicator: 'publicDebt', delta: 2, delay: 0, duration: 0 },
+              { indicator: 'gdpGrowth', delta: 0.3, delay: 2, duration: 4 },
+              { indicator: 'socialStrain', delta: -2, delay: 4, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'love', socialDems: 'meh', green: 'frown' },
+            hasEcho: true,
+          },
+          {
+            label: 'Do nothing — the market will find equilibrium',
+            description: 'A neoliberal cliché, delivered with conviction.',
+            effects: [
+              { indicator: 'socialStrain', delta: 3, delay: 1, duration: 2 },
+              { indicator: 'emigrationRate', delta: 2, delay: 2, duration: 3 },
+            ],
+            factionReactions: { entrepreneurs: 'cheer', socialDems: 'rage' },
+            humor: 'A pundit on TV3 says "supply and demand" twelve times in fourteen minutes.',
+          },
+        ],
+      }),
+    },
+    {
+      number: 2,
+      minDelay: 2,
+      maxDelay: 3,
+      build: () => ({
+        id: 'arc_rigaHousing_2',
+        title: '🪧 Referendum: Cap or Build?',
+        description: 'A citizens\' petition for a national referendum on housing policy has crossed the threshold. The Saeima must respond.',
+        preconditions: [],
+        category: 'petition',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Hold the referendum on schedule',
+            description: 'Democracy at work. The campaign will be loud.',
+            effects: [
+              { indicator: 'mediaTrust', delta: 4, delay: 1, duration: 0 },
+              { indicator: 'socialStrain', delta: 2, delay: 0, duration: 1 },
+            ],
+            factionReactions: { reformBloc: 'love', socialDems: 'cheer' },
+          },
+          {
+            label: 'Pre-empt with a parliamentary compromise',
+            description: 'Pass a moderate bill before the referendum date. Steals the energy. Costs trust.',
+            effects: [
+              { indicator: 'mediaTrust', delta: -3, delay: 1, duration: 0 },
+              { indicator: 'socialStrain', delta: -3, delay: 1, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'cheer', reformBloc: 'frown' },
+          },
+        ],
+      }),
+    },
+    {
+      number: 3,
+      minDelay: 4,
+      maxDelay: 6,
+      build: () => ({
+        id: 'arc_rigaHousing_3',
+        title: '🏁 Housing Crisis: The Resolution',
+        description: 'Two years on, the crisis has resolved — for now. The verdict from the polls, the press, and the rental listings:',
+        preconditions: [],
+        category: 'society',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Declare victory',
+            description: 'Prime ministerial press conference. Lectern. Latvian flag. Stable rents (mostly).',
+            effects: [
+              { indicator: 'publicConfidence', delta: 4, delay: 0, duration: 0 },
+              { indicator: 'mediaTrust', delta: 2, delay: 0, duration: 0 },
+            ],
+            factionReactions: { socialDems: 'cheer', entrepreneurs: 'meh' },
+            humor: 'A reporter asks about the next housing crisis. The PM looks pained.',
+          },
+          {
+            label: 'Pivot to the next issue',
+            description: 'Housing is sorted (for now). Let the file go quiet.',
+            effects: [
+              { indicator: 'publicConfidence', delta: 2, delay: 0, duration: 0 },
+            ],
+            factionReactions: { reformBloc: 'meh' },
+          },
+        ],
+      }),
+    },
+  ],
+};
+
+// ─── Arc 2: The Brain Drain Spiral ───────────────────────────────
+const BRAIN_DRAIN: ArcDef = {
+  id: 'brainDrain',
+  title: 'The Brain Drain Spiral',
+  canTrigger: (s, t) => t >= 8 && s.indicators.emigrationRate > 55,
+  stages: [
+    {
+      number: 1,
+      minDelay: 0,
+      maxDelay: 1,
+      build: () => ({
+        id: 'arc_brainDrain_1',
+        title: '✈️ The Dublin Pull',
+        description: 'The 2026 emigration figures are in. They are worse than 2025\'s. The diaspora WhatsApp groups now organise welcome dinners by city.',
+        preconditions: [],
+        category: 'society',
+        weight: 100,
+        oneTime: true,
+        highStakes: true,
+        choices: [
+          {
+            label: 'Launch a "Return to Latvia" tax incentive',
+            description: 'Returnees get 5 years of reduced income tax. Estonia did this. It worked. A little.',
+            effects: [
+              { indicator: 'emigrationRate', delta: -3, delay: 2, duration: 4 },
+              { indicator: 'publicDebt', delta: 2, delay: 1, duration: 0 },
+              { indicator: 'foreignInvestment', delta: 2, delay: 2, duration: 0 },
+            ],
+            factionReactions: { identity: 'cheer', entrepreneurs: 'cheer', socialDems: 'meh' },
+            hasEcho: true,
+          },
+          {
+            label: 'Liberalise immigration from Ukraine and the Caucasus',
+            description: 'Fill the workforce gap from elsewhere. National Identity bloc will not enjoy this.',
+            effects: [
+              { indicator: 'workforceSkill', delta: 4, delay: 3, duration: 0 },
+              { indicator: 'population', delta: 0.01, delay: 4, duration: 0 },
+              { indicator: 'nationalIdentity', delta: -4, delay: 1, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'love', identity: 'rage', socialDems: 'cheer' },
+          },
+          {
+            label: 'Treat it as a structural feature',
+            description: '"Emigration is a market signal," says no Latvian. But it sounds policy-grade in English.',
+            effects: [
+              { indicator: 'publicConfidence', delta: -3, delay: 1, duration: 0 },
+            ],
+            factionReactions: { identity: 'rage', socialDems: 'frown' },
+            humor: 'The PM\'s spin doctor resigns. Or is reassigned. The press release is unclear.',
+          },
+        ],
+      }),
+    },
+    {
+      number: 2,
+      minDelay: 3,
+      maxDelay: 5,
+      build: () => ({
+        id: 'arc_brainDrain_2',
+        title: '🛬 The Diaspora Lobby',
+        description: 'Latvians in Dublin, Berlin and London have organised. They have a name (Atpakaļ Mājās), a budget, and an op-ed in DELFI weekly.',
+        preconditions: [],
+        category: 'society',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Open formal channels — give them advisory seats',
+            description: 'The diaspora gets a voice in the Saeima\'s economic committee.',
+            effects: [
+              { indicator: 'emigrationRate', delta: -2, delay: 2, duration: 2 },
+              { indicator: 'mediaTrust', delta: 3, delay: 1, duration: 0 },
+            ],
+            factionReactions: { reformBloc: 'cheer', identity: 'frown' },
+          },
+          {
+            label: 'Quietly ignore them',
+            description: 'They\'ll lose interest by the next World Cup.',
+            effects: [
+              { indicator: 'mediaTrust', delta: -2, delay: 1, duration: 0 },
+            ],
+            factionReactions: { identity: 'meh' },
+          },
+        ],
+      }),
+    },
+    {
+      number: 3,
+      minDelay: 6,
+      maxDelay: 9,
+      build: () => ({
+        id: 'arc_brainDrain_3',
+        title: '🏁 Brain Drain: A Reckoning',
+        description: 'The arc concludes with a hard number: the net migration figure for the term. The historians will use this graph for years.',
+        preconditions: [],
+        category: 'society',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Accept the verdict — and pivot',
+            description: 'A grown-up press conference. A new policy package on demographics.',
+            effects: [{ indicator: 'publicConfidence', delta: 3, delay: 0, duration: 0 }],
+            factionReactions: { reformBloc: 'cheer' },
+          },
+          {
+            label: 'Reframe it as transformation, not decline',
+            description: 'The "smaller, smarter Latvia" speech. Some buy it.',
+            effects: [
+              { indicator: 'publicConfidence', delta: 1, delay: 0, duration: 0 },
+              { indicator: 'socialStrain', delta: 2, delay: 1, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'cheer', socialDems: 'frown' },
+          },
+        ],
+      }),
+    },
+  ],
+};
+
+// ─── Arc 3: Rail Baltica Saga (deep extension) ───────────────────
+const RAIL_BALTICA_SAGA: ArcDef = {
+  id: 'railBaltica',
+  title: 'The Rail Baltica Saga',
+  canTrigger: (s, t) => t >= 6 && (s.indicators.portActivity ?? 0) > 0,
+  stages: [
+    {
+      number: 1,
+      minDelay: 0,
+      maxDelay: 1,
+      build: () => ({
+        id: 'arc_railBaltica_1',
+        title: '🚄 Rail Baltica: The First Sleeper',
+        description: 'A photo of the first laid section south of Salacgrīva makes the news. Engineers shake hands. Estonian engineers shake hands more vigorously.',
+        preconditions: [],
+        category: 'economy',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Accelerate Latvian segment',
+            description: 'Pour money. Catch up to Estonia. Brussels approves.',
+            effects: [
+              { indicator: 'publicDebt', delta: 3, delay: 0, duration: 0 },
+              { indicator: 'gdpGrowth', delta: 0.4, delay: 2, duration: 6 },
+              { indicator: 'euStanding', delta: 3, delay: 1, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'cheer', reformBloc: 'cheer' },
+          },
+          {
+            label: 'Stick to the existing timeline',
+            description: 'Patience. Process. Latvian style.',
+            effects: [{ indicator: 'euStanding', delta: -1, delay: 1, duration: 0 }],
+            factionReactions: { entrepreneurs: 'meh', reformBloc: 'meh' },
+          },
+        ],
+      }),
+    },
+    {
+      number: 2,
+      minDelay: 3,
+      maxDelay: 5,
+      build: () => ({
+        id: 'arc_railBaltica_2',
+        title: '🏗️ Construction Scandal',
+        description: 'A subcontractor — three layers below the prime — has been found inflating invoices. KNAB is interested. So are journalists.',
+        preconditions: [],
+        category: 'crisis',
+        weight: 100,
+        oneTime: true,
+        highStakes: true,
+        choices: [
+          {
+            label: 'Cooperate fully with KNAB',
+            description: 'Transparency. Even if it embarrasses the Infrastructure Minister.',
+            effects: [
+              { indicator: 'corruptionLevel', delta: -3, delay: 2, duration: 0 },
+              { indicator: 'mediaTrust', delta: 4, delay: 1, duration: 0 },
+            ],
+            factionReactions: { reformBloc: 'love', entrepreneurs: 'frown' },
+          },
+          {
+            label: 'Quietly settle the contract dispute',
+            description: 'Make it go away. The minister keeps his job.',
+            effects: [
+              { indicator: 'corruptionLevel', delta: 4, delay: 1, duration: 0 },
+              { indicator: 'mediaTrust', delta: -4, delay: 1, duration: 0 },
+            ],
+            factionReactions: { reformBloc: 'rage', entrepreneurs: 'meh' },
+            hasEcho: true,
+          },
+        ],
+      }),
+    },
+    {
+      number: 3,
+      minDelay: 7,
+      maxDelay: 10,
+      build: () => ({
+        id: 'arc_railBaltica_3',
+        title: '🎉 The Ribbon Cutting',
+        description: 'The Latvian segment opens. A train from Tallinn arrives at Riga Central. Behind schedule. Within budget — if you squint.',
+        preconditions: [],
+        category: 'economy',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Bask in the moment',
+            description: 'You ride the inaugural train. Photo with the President.',
+            effects: [
+              { indicator: 'publicConfidence', delta: 6, delay: 0, duration: 0 },
+              { indicator: 'euStanding', delta: 4, delay: 0, duration: 0 },
+              { indicator: 'portActivity', delta: 8, delay: 1, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'love', reformBloc: 'cheer' },
+            humor: 'The President\'s speech mentions amber 11 times. A record.',
+          },
+        ],
+      }),
+    },
+  ],
+};
+
+// ─── Arc 4: The Latgale Question ─────────────────────────────────
+const LATGALE: ArcDef = {
+  id: 'latgale',
+  title: 'The Latgale Question',
+  canTrigger: (s, t) => t >= 6 && (s.indicators.russianMinorityIntegration ?? 50) < 45,
+  stages: [
+    {
+      number: 1,
+      minDelay: 0,
+      maxDelay: 1,
+      build: () => ({
+        id: 'arc_latgale_1',
+        title: '🗣️ Daugavpils Tensions',
+        description: 'Russian-language schools in Daugavpils protest a new curriculum law. The protests are peaceful. Footage is everywhere.',
+        preconditions: [],
+        category: 'society',
+        weight: 100,
+        oneTime: true,
+        highStakes: true,
+        choices: [
+          {
+            label: 'Sit down with the school principals',
+            description: 'Dialogue. Compromise on transitional periods.',
+            effects: [
+              { indicator: 'russianMinorityIntegration', delta: 5, delay: 1, duration: 0 },
+              { indicator: 'socialCohesion', delta: 3, delay: 1, duration: 0 },
+              { indicator: 'nationalIdentity', delta: -2, delay: 1, duration: 0 },
+            ],
+            factionReactions: { minority: 'love', identity: 'frown' },
+          },
+          {
+            label: 'Enforce the law without exceptions',
+            description: 'A nation has one language for state business.',
+            effects: [
+              { indicator: 'nationalIdentity', delta: 4, delay: 1, duration: 0 },
+              { indicator: 'russianMinorityIntegration', delta: -6, delay: 1, duration: 0 },
+              { indicator: 'socialStrain', delta: 4, delay: 2, duration: 2 },
+            ],
+            factionReactions: { identity: 'cheer', minority: 'rage' },
+          },
+        ],
+      }),
+    },
+    {
+      number: 2,
+      minDelay: 3,
+      maxDelay: 6,
+      build: () => ({
+        id: 'arc_latgale_2',
+        title: '🏛️ Latgale: The Long View',
+        description: 'A year on, the situation has settled — or hardened. The choice now is whether to invest in the region.',
+        preconditions: [],
+        category: 'society',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Major regional development package for Latgale',
+            description: 'Infrastructure, schools, hospitals. A signal.',
+            effects: [
+              { indicator: 'publicDebt', delta: 3, delay: 0, duration: 0 },
+              { indicator: 'russianMinorityIntegration', delta: 6, delay: 2, duration: 0 },
+              { indicator: 'socialCohesion', delta: 4, delay: 2, duration: 0 },
+            ],
+            factionReactions: { minority: 'love', socialDems: 'cheer', entrepreneurs: 'meh' },
+          },
+          {
+            label: 'Let market forces work',
+            description: 'Eastern Latvia will adjust. Or empty.',
+            effects: [
+              { indicator: 'emigrationRate', delta: 2, delay: 2, duration: 3 },
+              { indicator: 'socialCohesion', delta: -3, delay: 1, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'cheer', minority: 'frown' },
+          },
+        ],
+      }),
+    },
+  ],
+};
+
+// ─── Arc 5: The Energy Pivot ─────────────────────────────────────
+const ENERGY_PIVOT: ArcDef = {
+  id: 'energyPivot',
+  title: 'The Energy Pivot',
+  canTrigger: (s, t) => t >= 4 && s.indicators.energyIndependence < 60,
+  stages: [
+    {
+      number: 1,
+      minDelay: 0,
+      maxDelay: 1,
+      build: () => ({
+        id: 'arc_energyPivot_1',
+        title: '⚡ Gas Decoupling: The Last Cubic Metre',
+        description: 'The contract with Russia\'s Gazprom finally lapses. The replacement LNG terminal at Skulte is over budget. The Norwegians are friendly but expensive.',
+        preconditions: [],
+        category: 'economy',
+        weight: 100,
+        oneTime: true,
+        highStakes: true,
+        choices: [
+          {
+            label: 'Accelerate wind buildout in Kurzeme',
+            description: 'Long lead time. Right answer. Voters in the meantime — patient or angry?',
+            effects: [
+              { indicator: 'greenTransition', delta: 6, delay: 2, duration: 0 },
+              { indicator: 'energyIndependence', delta: 8, delay: 4, duration: 0 },
+              { indicator: 'publicDebt', delta: 3, delay: 0, duration: 0 },
+            ],
+            factionReactions: { green: 'love', entrepreneurs: 'meh' },
+            hasEcho: true,
+          },
+          {
+            label: 'Long-term LNG supply deal',
+            description: 'Norwegian gas, locked in for a decade. Expensive. Predictable.',
+            effects: [
+              { indicator: 'energyIndependence', delta: 5, delay: 1, duration: 0 },
+              { indicator: 'greenTransition', delta: -3, delay: 1, duration: 0 },
+              { indicator: 'publicDebt', delta: 2, delay: 0, duration: 0 },
+            ],
+            factionReactions: { entrepreneurs: 'cheer', green: 'rage' },
+          },
+        ],
+      }),
+    },
+    {
+      number: 2,
+      minDelay: 4,
+      maxDelay: 8,
+      build: () => ({
+        id: 'arc_energyPivot_2',
+        title: '🌬️ The Grid Holds',
+        description: 'A cold January. Demand spikes. The grid is tested. Engineers, exhausted, deliver a verdict.',
+        preconditions: [],
+        category: 'crisis',
+        weight: 100,
+        oneTime: true,
+        choices: [
+          {
+            label: 'Praise the engineers publicly',
+            description: 'A speech. A medal. A quiet bonus.',
+            effects: [
+              { indicator: 'publicConfidence', delta: 5, delay: 0, duration: 0 },
+              { indicator: 'mediaTrust', delta: 2, delay: 0, duration: 0 },
+            ],
+            factionReactions: { green: 'cheer', reformBloc: 'cheer' },
+            humor: 'The engineers seem genuinely surprised to be on television.',
+          },
+        ],
+      }),
+    },
+  ],
+};
+
+export const ARCS: ArcDef[] = [RIGA_HOUSING, BRAIN_DRAIN, RAIL_BALTICA_SAGA, LATGALE, ENERGY_PIVOT];
+
+/**
+ * Check which arcs should trigger this turn (move from "available" to active).
+ * Pure function.
+ */
+export function checkArcTriggers(
+  active: ActiveArc[],
+  completed: Set<ArcId>,
+  state: GameState,
+  currentTurn: number,
+): ActiveArc[] {
+  const out = [...active];
+  const activeIds = new Set(active.map(a => a.arcId));
+  for (const arc of ARCS) {
+    if (activeIds.has(arc.id) || completed.has(arc.id)) continue;
+    if (arc.canTrigger(state, currentTurn)) {
+      out.push({ arcId: arc.id, stage: 0, turnStarted: currentTurn });
+      // Only one new arc per turn to avoid flooding
+      break;
+    }
+  }
+  return out;
+}
+
+/**
+ * Get the next arc stage event ready to fire this turn, or null.
+ */
+export function nextArcEvent(active: ActiveArc, currentTurn: number, state: GameState): { event: GameEvent | null; readyArc: ActiveArc | null } {
+  const arc = ARCS.find(a => a.id === active.arcId);
+  if (!arc) return { event: null, readyArc: null };
+  const nextStageNumber = active.stage + 1;
+  const stage = arc.stages.find(s => s.number === nextStageNumber);
+  if (!stage) return { event: null, readyArc: null };
+  const elapsed = currentTurn - active.turnStarted;
+  if (elapsed < stage.minDelay) return { event: null, readyArc: null };
+  return { event: stage.build(state), readyArc: { ...active, stage: nextStageNumber } };
+}

--- a/src/engine/constitution.ts
+++ b/src/engine/constitution.ts
@@ -1,0 +1,161 @@
+/**
+ * Constitution Builder — Frostpunk Book of Laws, Latvia-flavoured.
+ *
+ * 4 pillars, each with positions -2..+2 (5 steps). Moving along a pillar
+ * costs Political Capital. Movement is forbidden in the reverse direction —
+ * you can stay or advance, never retreat. This is an *ideological* track,
+ * not a tunable parameter.
+ *
+ * Each step unlocks/locks event pools and gives small permanent indicator
+ * shifts. Position is visible on the always-on banner.
+ */
+
+export type PillarId = 'economic' | 'foreign' | 'civil' | 'environment';
+
+export interface PillarPosition {
+  id: PillarId;
+  position: number; // -2..+2, starts at 0
+}
+
+export interface PillarStepDef {
+  /** New position the player would move to (-2..+2). */
+  position: number;
+  label: string;
+  description: string;
+  /** PC cost to advance into this position from the previous one. */
+  cost: number;
+  /** Permanent indicator deltas applied when entering this position. */
+  effects: { indicator: string; delta: number }[];
+  /** Faction starting bias deltas (factionId -> delta) applied on entry. */
+  factionBias?: Record<string, number>;
+}
+
+export interface PillarDef {
+  id: PillarId;
+  emoji: string;
+  name: string;
+  axisLeft: string;
+  axisRight: string;
+  /** Step definitions keyed by position. -2..+2 */
+  steps: Record<number, PillarStepDef>;
+}
+
+export const PILLARS: PillarDef[] = [
+  {
+    id: 'economic',
+    emoji: '💼',
+    name: 'Economic Model',
+    axisLeft: 'State-Led',
+    axisRight: 'Free Market',
+    steps: {
+      [-2]: { position: -2, label: 'State-Led Industry', cost: 12, description: 'Public ownership of key sectors. Investment banks frown.', effects: [{ indicator: 'foreignInvestment', delta: -8 }, { indicator: 'gdpGrowth', delta: -0.5 }, { indicator: 'socialCohesion', delta: 4 }], factionBias: { socialDems: 10, entrepreneurs: -10 } },
+      [-1]: { position: -1, label: 'Strong Public Sector', cost: 6, description: 'Tilt the mixed economy further to the state side.', effects: [{ indicator: 'healthcareQuality', delta: 4 }, { indicator: 'foreignInvestment', delta: -4 }], factionBias: { socialDems: 5, entrepreneurs: -4 } },
+      [0]: { position: 0, label: 'Mixed Economy', cost: 0, description: 'The default Latvian compromise. Everyone is mildly dissatisfied.', effects: [] },
+      [1]: { position: 1, label: 'Business-Friendly', cost: 6, description: 'Cut red tape, deregulate strategic sectors.', effects: [{ indicator: 'foreignInvestment', delta: 6 }, { indicator: 'taxBurden', delta: -3 }], factionBias: { entrepreneurs: 6, socialDems: -3 } },
+      [2]: { position: 2, label: 'Full Free Market', cost: 12, description: 'Privatise everything that does not move. Brussels asks pointed questions.', effects: [{ indicator: 'foreignInvestment', delta: 12 }, { indicator: 'taxBurden', delta: -6 }, { indicator: 'healthcareQuality', delta: -5 }], factionBias: { entrepreneurs: 12, socialDems: -10 } },
+    },
+  },
+  {
+    id: 'foreign',
+    emoji: '🌍',
+    name: 'Foreign Alignment',
+    axisLeft: 'Neutral Pragmatic',
+    axisRight: 'Strict Euro-Atlantic',
+    steps: {
+      [-2]: { position: -2, label: 'Active Non-Alignment', cost: 14, description: 'Hedging between East and West. NATO sends carefully-worded letters.', effects: [{ indicator: 'natoRelations', delta: -15 }, { indicator: 'russiaRelations', delta: 6 }, { indicator: 'euStanding', delta: -10 }], factionBias: { natoBloc: -15 } },
+      [-1]: { position: -1, label: 'Quiet Diplomacy', cost: 6, description: 'Less rhetoric, more back-channels.', effects: [{ indicator: 'natoRelations', delta: -5 }], factionBias: { natoBloc: -5 } },
+      [0]: { position: 0, label: 'Standard Alignment', cost: 0, description: 'EU and NATO member doing its part. No surprises.', effects: [] },
+      [1]: { position: 1, label: 'Forward Atlanticism', cost: 6, description: 'Lean into the alliance. Send the F-35 wishlist again.', effects: [{ indicator: 'natoRelations', delta: 6 }, { indicator: 'militaryReadiness', delta: 4 }], factionBias: { natoBloc: 6, reformBloc: 4 } },
+      [2]: { position: 2, label: 'Frontline State Doctrine', cost: 14, description: 'Defence-first foreign policy. The Eastern Brigade gets a budget.', effects: [{ indicator: 'natoRelations', delta: 12 }, { indicator: 'militaryReadiness', delta: 10 }, { indicator: 'russiaRelations', delta: -10 }], factionBias: { natoBloc: 15, reformBloc: 4 } },
+    },
+  },
+  {
+    id: 'civil',
+    emoji: '⚖️',
+    name: 'Civil Order',
+    axisLeft: 'Protective Authoritarian',
+    axisRight: 'Open Liberal',
+    steps: {
+      [-2]: { position: -2, label: 'Security State', cost: 14, description: 'Surveillance, expanded police, restricted press. The constitutional court is busy.', effects: [{ indicator: 'borderSecurity', delta: 10 }, { indicator: 'cyberDefense', delta: 8 }, { indicator: 'mediaTrust', delta: -10 }, { indicator: 'socialCohesion', delta: -8 }], factionBias: { reformBloc: -12 } },
+      [-1]: { position: -1, label: 'Order First', cost: 6, description: 'Hard line on disorder, looser on civil rights.', effects: [{ indicator: 'borderSecurity', delta: 5 }, { indicator: 'mediaTrust', delta: -3 }], factionBias: { reformBloc: -5 } },
+      [0]: { position: 0, label: 'Balanced Liberty', cost: 0, description: 'Civil rights with normal-country exceptions.', effects: [] },
+      [1]: { position: 1, label: 'Open Society', cost: 6, description: 'Press freedom expanded; KNAB given teeth.', effects: [{ indicator: 'mediaTrust', delta: 6 }, { indicator: 'corruptionLevel', delta: -4 }], factionBias: { reformBloc: 6 } },
+      [2]: { position: 2, label: 'Full Liberal Constitutionalism', cost: 14, description: 'Judicial independence, transparent procurement, robust press. KNAB hires actual auditors.', effects: [{ indicator: 'mediaTrust', delta: 12 }, { indicator: 'corruptionLevel', delta: -10 }, { indicator: 'euStanding', delta: 6 }], factionBias: { reformBloc: 12 } },
+    },
+  },
+  {
+    id: 'environment',
+    emoji: '🌿',
+    name: 'Environmental Posture',
+    axisLeft: 'Industrial Growth',
+    axisRight: 'Green Mandate',
+    steps: {
+      [-2]: { position: -2, label: 'Growth First', cost: 12, description: 'Loosen environmental review for major projects. Brussels schedules a meeting.', effects: [{ indicator: 'gdpGrowth', delta: 0.6 }, { indicator: 'greenTransition', delta: -10 }, { indicator: 'euStanding', delta: -4 }], factionBias: { green: -15 } },
+      [-1]: { position: -1, label: 'Industry-Friendly', cost: 6, description: 'Tilt regulatory regime toward producers.', effects: [{ indicator: 'gdpGrowth', delta: 0.3 }, { indicator: 'greenTransition', delta: -4 }], factionBias: { green: -5, entrepreneurs: 4 } },
+      [0]: { position: 0, label: 'Balanced Pace', cost: 0, description: 'EU green targets met "broadly". Latvian compromise.', effects: [] },
+      [1]: { position: 1, label: 'Green Acceleration', cost: 6, description: 'Faster renewable deployment, stricter permitting.', effects: [{ indicator: 'greenTransition', delta: 6 }, { indicator: 'energyIndependence', delta: 4 }], factionBias: { green: 6 } },
+      [2]: { position: 2, label: 'Green Mandate', cost: 12, description: 'Carbon neutrality by 2040 is law. The wind turbines outnumber the storks.', effects: [{ indicator: 'greenTransition', delta: 12 }, { indicator: 'energyIndependence', delta: 8 }, { indicator: 'euStanding', delta: 4 }, { indicator: 'gdpGrowth', delta: -0.3 }], factionBias: { green: 15, entrepreneurs: -5 } },
+    },
+  },
+];
+
+export interface ConstitutionState {
+  positions: Record<PillarId, number>;
+  /** Political capital reserve — earned per turn, spent on amendments. */
+  politicalCapital: number;
+}
+
+export function createInitialConstitution(): ConstitutionState {
+  return {
+    positions: { economic: 0, foreign: 0, civil: 0, environment: 0 },
+    politicalCapital: 4,
+  };
+}
+
+/** Can the player advance the given pillar one step in `direction`? */
+export function canAdvancePillar(
+  c: ConstitutionState,
+  pillar: PillarId,
+  direction: 1 | -1,
+): { ok: boolean; reason?: string; cost?: number } {
+  const cur = c.positions[pillar];
+  const target = cur + direction;
+  if (target < -2 || target > 2) return { ok: false, reason: 'Edge of the constitutional spectrum.' };
+  const pillarDef = PILLARS.find(p => p.id === pillar);
+  if (!pillarDef) return { ok: false, reason: 'Unknown pillar.' };
+
+  // One-way ladder rule: once you've moved away from 0, you can only continue
+  // in that direction — never reverse.
+  if (cur > 0 && direction < 0) return { ok: false, reason: 'Constitutional amendments are not reversible.' };
+  if (cur < 0 && direction > 0) return { ok: false, reason: 'Constitutional amendments are not reversible.' };
+
+  const step = pillarDef.steps[target];
+  if (!step) return { ok: false, reason: 'Step definition missing.' };
+  if (c.politicalCapital < step.cost) return { ok: false, reason: `Needs ${step.cost} Political Capital — you have ${c.politicalCapital}.` };
+  return { ok: true, cost: step.cost };
+}
+
+/** Advance the pillar — returns new constitution state + step deltas to apply elsewhere. */
+export function advancePillar(
+  c: ConstitutionState,
+  pillar: PillarId,
+  direction: 1 | -1,
+): { next: ConstitutionState; step: PillarStepDef | null } {
+  const check = canAdvancePillar(c, pillar, direction);
+  if (!check.ok) return { next: c, step: null };
+  const target = c.positions[pillar] + direction;
+  const pillarDef = PILLARS.find(p => p.id === pillar)!;
+  const step = pillarDef.steps[target];
+  return {
+    next: {
+      positions: { ...c.positions, [pillar]: target },
+      politicalCapital: c.politicalCapital - (check.cost ?? 0),
+    },
+    step,
+  };
+}
+
+/** Earn Political Capital — called from turn.ts each quarter. */
+export function earnPoliticalCapital(c: ConstitutionState, base: number = 1, bonus: number = 0): ConstitutionState {
+  return { ...c, politicalCapital: Math.min(40, c.politicalCapital + base + bonus) };
+}

--- a/src/engine/decrees.ts
+++ b/src/engine/decrees.ts
@@ -1,0 +1,266 @@
+import type { GameState } from './types';
+
+/**
+ * Tropico-style Edicts — toggleable persistent policies.
+ *
+ * Each decree, while active, applies an ongoing per-quarter effect to a
+ * set of indicators. Revoking has a Political Capital cost and triggers
+ * a "U-turn" headline (handled via newsfeed).
+ *
+ * Decrees live separately from event choices. They're a strategic
+ * background layer — set them and forget them; un-set them and pay.
+ */
+
+export interface DecreeDef {
+  id: string;
+  emoji: string;
+  name: string;
+  description: string;
+  /** PC cost to enact. */
+  enactCost: number;
+  /** PC cost to revoke (always > enactCost). */
+  revokeCost: number;
+  /** Per-quarter indicator deltas while active. */
+  perQuarter: { indicator: string; delta: number }[];
+  /** Faction approval impact when first enacted. */
+  factionReactions?: Record<string, 'love' | 'cheer' | 'meh' | 'frown' | 'rage'>;
+}
+
+export const DECREES: DecreeDef[] = [
+  {
+    id: 'baltic_investment_zone',
+    emoji: '🏗️',
+    name: 'Baltic Investment Zone',
+    description: 'Tax breaks for foreign capital in industrial parks. Investors smile. Small businesses do not.',
+    enactCost: 4,
+    revokeCost: 6,
+    perQuarter: [
+      { indicator: 'foreignInvestment', delta: 0.8 },
+      { indicator: 'taxBurden', delta: -0.15 },
+      { indicator: 'publicDebt', delta: 0.2 },
+    ],
+    factionReactions: { entrepreneurs: 'love', reformBloc: 'meh', socialDems: 'frown' },
+  },
+  {
+    id: 'latvian_public_sector',
+    emoji: '🇱🇻',
+    name: 'Mandatory Latvian in Public Sector',
+    description: 'All state services in Latvian only. National Identity cheers. Russian-speaking citizens, less so.',
+    enactCost: 5,
+    revokeCost: 8,
+    perQuarter: [
+      { indicator: 'nationalIdentity', delta: 0.6 },
+      { indicator: 'russianMinorityIntegration', delta: -0.6 },
+    ],
+    factionReactions: { identity: 'love', minority: 'rage', reformBloc: 'frown' },
+  },
+  {
+    id: 'emergency_housing',
+    emoji: '🏘️',
+    name: 'Emergency Housing Construction Program',
+    description: 'Government-backed construction in major cities. Cranes everywhere. Treasury sighs.',
+    enactCost: 6,
+    revokeCost: 8,
+    perQuarter: [
+      { indicator: 'gdpGrowth', delta: 0.1 },
+      { indicator: 'publicDebt', delta: 0.4 },
+      { indicator: 'publicConfidence', delta: 0.3 },
+      { indicator: 'socialStrain', delta: -0.2 },
+    ],
+    factionReactions: { socialDems: 'love', entrepreneurs: 'cheer', green: 'frown' },
+  },
+  {
+    id: 'cyber_hardening',
+    emoji: '🔒',
+    name: 'Cyber-Hardening Program',
+    description: 'Mandatory penetration testing across critical infrastructure. The IT department is busier — and angrier.',
+    enactCost: 4,
+    revokeCost: 5,
+    perQuarter: [
+      { indicator: 'cyberDefense', delta: 0.5 },
+      { indicator: 'digitalInfra', delta: -0.1 },
+    ],
+    factionReactions: { natoBloc: 'cheer', reformBloc: 'cheer' },
+  },
+  {
+    id: 'visa_free_tech',
+    emoji: '💻',
+    name: 'Visa-Free Tech Worker Channel',
+    description: 'Fast-track residency for tech workers from select countries. Startups rejoice. The interior ministry side-eyes.',
+    enactCost: 5,
+    revokeCost: 6,
+    perQuarter: [
+      { indicator: 'techSector', delta: 0.4 },
+      { indicator: 'foreignInvestment', delta: 0.3 },
+      { indicator: 'nationalIdentity', delta: -0.2 },
+    ],
+    factionReactions: { entrepreneurs: 'love', identity: 'frown', socialDems: 'meh' },
+  },
+  {
+    id: 'diaspora_return',
+    emoji: '🛬',
+    name: 'Diaspora Return Incentive',
+    description: '5-year tax discount for returnees. Dublin Latvians take meetings.',
+    enactCost: 4,
+    revokeCost: 5,
+    perQuarter: [
+      { indicator: 'emigrationRate', delta: -0.3 },
+      { indicator: 'population', delta: 0.002 },
+      { indicator: 'publicDebt', delta: 0.1 },
+    ],
+    factionReactions: { identity: 'love', entrepreneurs: 'cheer', socialDems: 'cheer' },
+  },
+  {
+    id: 'wind_corridor',
+    emoji: '🌬️',
+    name: 'Kurzeme Wind Corridor',
+    description: 'Streamlined permits for offshore wind. Storks complain. Engineers cheer.',
+    enactCost: 5,
+    revokeCost: 6,
+    perQuarter: [
+      { indicator: 'greenTransition', delta: 0.5 },
+      { indicator: 'energyIndependence', delta: 0.4 },
+    ],
+    factionReactions: { green: 'love', entrepreneurs: 'cheer' },
+  },
+  {
+    id: 'knab_independence',
+    emoji: '⚖️',
+    name: 'KNAB Independence Charter',
+    description: 'Anti-corruption agency reports directly to Saeima. KNAB hires faster. Procurement officers update their CVs.',
+    enactCost: 6,
+    revokeCost: 10,
+    perQuarter: [
+      { indicator: 'corruptionLevel', delta: -0.4 },
+      { indicator: 'mediaTrust', delta: 0.3 },
+    ],
+    factionReactions: { reformBloc: 'love', entrepreneurs: 'frown' },
+  },
+  {
+    id: 'rural_basic_income',
+    emoji: '🌾',
+    name: 'Rural Basic Income Pilot',
+    description: 'A modest stipend to rural households in Latgale and Vidzeme. Treasury creaks. Villages exhale.',
+    enactCost: 6,
+    revokeCost: 9,
+    perQuarter: [
+      { indicator: 'socialCohesion', delta: 0.4 },
+      { indicator: 'publicDebt', delta: 0.3 },
+      { indicator: 'emigrationRate', delta: -0.2 },
+    ],
+    factionReactions: { socialDems: 'love', identity: 'cheer', entrepreneurs: 'frown' },
+  },
+  {
+    id: 'song_festival_funding',
+    emoji: '🎤',
+    name: 'Song Festival Trust Fund',
+    description: 'Permanent endowment for the Song & Dance Festival. National identity index quietly thanks you every June.',
+    enactCost: 3,
+    revokeCost: 8,
+    perQuarter: [
+      { indicator: 'nationalIdentity', delta: 0.3 },
+      { indicator: 'publicConfidence', delta: 0.2 },
+    ],
+    factionReactions: { identity: 'love' },
+  },
+  {
+    id: 'startup_grant_engine',
+    emoji: '🚀',
+    name: 'Startup Grant Engine',
+    description: 'Seed grants up to €100k for Latvian-founded startups. MikroTīkls says nothing. Quietly approves.',
+    enactCost: 4,
+    revokeCost: 5,
+    perQuarter: [
+      { indicator: 'techSector', delta: 0.5 },
+      { indicator: 'rdSpending', delta: 0.02 },
+      { indicator: 'publicDebt', delta: 0.1 },
+    ],
+    factionReactions: { entrepreneurs: 'love', reformBloc: 'cheer' },
+  },
+  {
+    id: 'frontline_brigade',
+    emoji: '🛡️',
+    name: 'Permanent Eastern Brigade',
+    description: 'Standing army formation east of Daugavpils. The General Staff stops phoning at midnight.',
+    enactCost: 6,
+    revokeCost: 8,
+    perQuarter: [
+      { indicator: 'militaryReadiness', delta: 0.5 },
+      { indicator: 'borderSecurity', delta: 0.4 },
+      { indicator: 'publicDebt', delta: 0.3 },
+      { indicator: 'russiaRelations', delta: -0.2 },
+    ],
+    factionReactions: { natoBloc: 'love', minority: 'frown' },
+  },
+];
+
+export interface DecreeState {
+  active: string[]; // decree ids
+  history: { id: string; turn: number; action: 'enacted' | 'revoked' }[];
+}
+
+export function createInitialDecrees(): DecreeState {
+  return { active: [], history: [] };
+}
+
+export function getDecree(id: string): DecreeDef | undefined {
+  return DECREES.find(d => d.id === id);
+}
+
+/** Apply per-quarter effects of all active decrees to the indicators. */
+export function applyDecreeEffects(decrees: DecreeState, indicators: Record<string, number>): Record<string, number> {
+  const next = { ...indicators };
+  for (const did of decrees.active) {
+    const d = getDecree(did);
+    if (!d) continue;
+    for (const eff of d.perQuarter) {
+      const cur = next[eff.indicator] ?? 0;
+      next[eff.indicator] = cur + eff.delta;
+    }
+  }
+  return next;
+}
+
+/** Can the player enact this decree right now? */
+export function canEnact(decrees: DecreeState, decreeId: string, politicalCapital: number): { ok: boolean; reason?: string } {
+  const d = getDecree(decreeId);
+  if (!d) return { ok: false, reason: 'Unknown decree.' };
+  if (decrees.active.includes(decreeId)) return { ok: false, reason: 'Already enacted.' };
+  if (politicalCapital < d.enactCost) return { ok: false, reason: `Needs ${d.enactCost} PC` };
+  return { ok: true };
+}
+
+export function enactDecree(state: GameState, decreeId: string): { state: GameState; def: DecreeDef | null } {
+  const def = getDecree(decreeId);
+  if (!def) return { state, def: null };
+  const check = canEnact(state.decrees, decreeId, state.constitution.politicalCapital);
+  if (!check.ok) return { state, def: null };
+  return {
+    state: {
+      ...state,
+      constitution: { ...state.constitution, politicalCapital: state.constitution.politicalCapital - def.enactCost },
+      decrees: {
+        active: [...state.decrees.active, decreeId],
+        history: [...state.decrees.history, { id: decreeId, turn: state.turn, action: 'enacted' }],
+      },
+    },
+    def,
+  };
+}
+
+export function revokeDecree(state: GameState, decreeId: string): { state: GameState; def: DecreeDef | null } {
+  const def = getDecree(decreeId);
+  if (!def || !state.decrees.active.includes(decreeId)) return { state, def: null };
+  if (state.constitution.politicalCapital < def.revokeCost) return { state, def: null };
+  return {
+    state: {
+      ...state,
+      constitution: { ...state.constitution, politicalCapital: state.constitution.politicalCapital - def.revokeCost },
+      decrees: {
+        active: state.decrees.active.filter(id => id !== decreeId),
+        history: [...state.decrees.history, { id: decreeId, turn: state.turn, action: 'revoked' }],
+      },
+    },
+    def,
+  };
+}

--- a/src/engine/echoes.ts
+++ b/src/engine/echoes.ts
@@ -1,0 +1,115 @@
+import type { Echo, GameEvent, Choice } from './types';
+import type { Rng } from './random';
+import { getIndicatorMeta } from './indicators';
+
+const QUARTER_SHORT = ['Q1', 'Q2', 'Q3', 'Q4'] as const;
+
+function quarterLabel(year: number, quarter: number): string {
+  return `${QUARTER_SHORT[quarter - 1]} ${year}`;
+}
+
+const ECHO_OPENERS = [
+  'Three quarters on,',
+  'It turns out,',
+  'A small ministry footnote reveals that',
+  'Buried in the latest CSP bulletin:',
+  "Now we know what the {{source}} actually meant —",
+  'A delayed consequence has surfaced —',
+  'The accountants finally finished the math:',
+];
+
+const ECHO_FRAMES_POS = [
+  'the {{source}} you signed in {{quarter}} has quietly paid off: {{indicator}} is doing better than the briefings predicted.',
+  '{{indicator}} climbed faster than the experts forecast after the {{source}} — even Brussels noticed.',
+  'someone in {{quarter}} did the maths right: {{indicator}} responded exactly the way the optimists hoped.',
+];
+
+const ECHO_FRAMES_NEG = [
+  'the {{source}} from {{quarter}} produced an unwelcome surprise — {{indicator}} slid more than anyone forecast.',
+  '{{indicator}} did not respond well to the {{source}}. A footnote in this quarter\'s memo: "as predicted by Ministry critics."',
+  'a slow-burning side-effect of the {{source}} has landed: {{indicator}} took the hit, three quarters late.',
+];
+
+const ECHO_FRAMES_NEUTRAL = [
+  'the {{source}} from {{quarter}} has had ambiguous results. {{indicator}} moved — economists disagree on whether that\'s good news.',
+  '{{indicator}} drifted in the direction the {{source}} pushed it. The {{quarter}} pundits feel vindicated. Everyone else moved on.',
+];
+
+function pickTemplate(frames: string[], rng: Rng): string {
+  return rng.pick(frames);
+}
+
+function fill(template: string, vars: Record<string, string>): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (_, k) => vars[k] ?? `{{${k}}}`);
+}
+
+/**
+ * Generate an Echo for a hasEcho-flagged choice, scheduled 2-4 turns from now.
+ * Pure function — caller appends the result to state.pendingEchoes.
+ */
+export function scheduleEcho(
+  event: GameEvent,
+  choice: Choice,
+  currentTurn: number,
+  year: number,
+  quarter: number,
+  rng: Rng,
+): Echo | null {
+  const dominantEffect = [...choice.effects]
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))[0];
+  if (!dominantEffect) return null;
+
+  const meta = getIndicatorMeta(dominantEffect.indicator);
+  if (!meta) return null;
+
+  const delay = rng.int(2, 4);
+  const sourceLabel = event.title.replace(/^[^\s]+\s/, ''); // strip leading emoji
+  const opener = fill(rng.pick(ECHO_OPENERS), { source: sourceLabel });
+
+  let frame: string;
+  if (meta.goodDirection === 'neutral') {
+    frame = pickTemplate(ECHO_FRAMES_NEUTRAL, rng);
+  } else {
+    const isGood =
+      (meta.goodDirection === 'up' && dominantEffect.delta > 0) ||
+      (meta.goodDirection === 'down' && dominantEffect.delta < 0);
+    frame = pickTemplate(isGood ? ECHO_FRAMES_POS : ECHO_FRAMES_NEG, rng);
+  }
+
+  const narrative = `${opener} ${fill(frame, {
+    source: sourceLabel,
+    quarter: quarterLabel(year, quarter),
+    indicator: meta.name,
+  })}`;
+
+  // Use choice.echoTemplate if provided (overrides procedural)
+  const finalNarrative = choice.echoTemplate
+    ? fill(choice.echoTemplate, {
+        source: sourceLabel,
+        quarter: quarterLabel(year, quarter),
+        indicator: meta.name,
+      })
+    : narrative;
+
+  return {
+    id: `echo_${event.id}_${currentTurn}`,
+    sourceEventTitle: event.title,
+    sourceQuarterLabel: quarterLabel(year, quarter),
+    fireTurn: currentTurn + delay,
+    narrative: finalNarrative,
+  };
+}
+
+/**
+ * Pull echoes that fire on the given turn out of the pending list.
+ * Returns [echoes-firing-now, echoes-still-pending].
+ */
+export function dueEchoes(pending: Echo[], turn: number): { fired: Echo[]; remaining: Echo[] } {
+  const fired: Echo[] = [];
+  const remaining: Echo[] = [];
+  for (const e of pending) {
+    if (e.fireTurn <= turn) fired.push(e);
+    else remaining.push(e);
+  }
+  return { fired, remaining };
+}

--- a/src/engine/effects.ts
+++ b/src/engine/effects.ts
@@ -2,6 +2,7 @@ import { GameState, Condition, ScheduledEffect, Effect } from './types';
 import { INDICATORS } from './indicators';
 import { clamp } from './random';
 import type { Rng } from './random';
+import { applyTraitEffectModifiers } from './traits';
 
 /** Check if a single condition is met */
 export function checkCondition(state: GameState, cond: Condition): boolean {
@@ -19,7 +20,19 @@ export function checkCondition(state: GameState, cond: Condition): boolean {
 
 /** Apply an effect: either immediately or schedule it */
 export function applyEffect(state: GameState, effect: Effect, source: string, rng: Rng): GameState {
-  const variedDelta = rng.vary(effect.delta, 0.15);
+  const traitModified = applyTraitEffectModifiers(effect, state.traits ?? []);
+  const variedDelta = rng.vary(traitModified.delta, 0.15);
+
+  // Dual-meter bridge: writes to publicHappiness split into Confidence + Strain
+  // so legacy events automatically feed the new two-bar tension model.
+  if (effect.indicator === 'publicHappiness' && effect.delay <= 0) {
+    if (effect.condition && !checkCondition(state, effect.condition)) {
+      return state;
+    }
+    let s = applyDelta(state, 'publicConfidence', variedDelta * 0.6, effect.duration, source, rng);
+    s = applyDelta(s, 'socialStrain', -variedDelta * 0.6, effect.duration, source, rng);
+    return s;
+  }
 
   if (effect.delay <= 0) {
     // Apply immediately
@@ -29,7 +42,7 @@ export function applyEffect(state: GameState, effect: Effect, source: string, rn
     return applyDelta(state, effect.indicator, variedDelta, effect.duration, source, rng);
   }
 
-  // Schedule for later
+  // Schedule for later — same split applied when the scheduled effect fires
   return {
     ...state,
     scheduledEffects: [
@@ -87,7 +100,12 @@ export function processScheduledEffects(state: GameState, rng: Rng): GameState {
       if (eff.condition && !checkCondition(newState, eff.condition)) {
         continue; // Condition not met, skip
       }
-      newState = applyDelta(newState, eff.indicator, eff.delta, eff.duration, eff.source, rng);
+      if (eff.indicator === 'publicHappiness') {
+        newState = applyDelta(newState, 'publicConfidence', eff.delta * 0.6, eff.duration, eff.source, rng);
+        newState = applyDelta(newState, 'socialStrain', -eff.delta * 0.6, eff.duration, eff.source, rng);
+      } else {
+        newState = applyDelta(newState, eff.indicator, eff.delta, eff.duration, eff.source, rng);
+      }
     } else {
       remaining.push({ ...eff, turnsRemaining: eff.turnsRemaining - 1 });
     }
@@ -159,14 +177,30 @@ export function applyCascadingEffects(state: GameState, _rng: Rng): GameState {
 
   // Low social cohesion → political instability
   if (ind.socialCohesion < 25) {
-    ind.publicHappiness = clamp(ind.publicHappiness - 0.5, 0, 100);
+    ind.publicConfidence = clamp((ind.publicConfidence ?? 50) - 0.4, 0, 100);
+    ind.socialStrain = clamp((ind.socialStrain ?? 50) + 0.4, 0, 100);
     ind.foreignInvestment = clamp(ind.foreignInvestment - 0.2, 0, 100);
   }
 
   // Very low Russia relations + low military → higher threat perception
   if (ind.russiaRelations < 20 && ind.militaryReadiness < 40) {
-    ind.publicHappiness = clamp(ind.publicHappiness - 0.3, 0, 100);
+    ind.publicConfidence = clamp((ind.publicConfidence ?? 50) - 0.3, 0, 100);
+    ind.socialStrain = clamp((ind.socialStrain ?? 50) + 0.2, 0, 100);
   }
+
+  // High unemployment also bites confidence directly
+  if (ind.unemployment > 12) {
+    ind.publicConfidence = clamp((ind.publicConfidence ?? 50) - 0.3, 0, 100);
+    ind.socialStrain = clamp((ind.socialStrain ?? 50) + 0.5, 0, 100);
+  }
+
+  // Slow recovery: confidence drifts toward 50, strain drifts down at rest
+  ind.publicConfidence = clamp((ind.publicConfidence ?? 50) + (50 - (ind.publicConfidence ?? 50)) * 0.02, 0, 100);
+  ind.socialStrain = clamp((ind.socialStrain ?? 50) - 0.15, 0, 100);
+
+  // Derive publicHappiness from the dual meter every turn
+  // (any direct event-writes to publicHappiness happened before cascading via the split bridge)
+  ind.publicHappiness = clamp(((ind.publicConfidence ?? 50) + (100 - (ind.socialStrain ?? 50))) / 2, 0, 100);
 
   return { ...state, indicators: ind };
 }
@@ -177,6 +211,12 @@ export function checkGameOver(state: GameState): GameState {
 
   if (ind.population < 1.2) {
     return { ...state, gameOver: true, gameOverReason: 'Latvia\'s population has fallen below 1.2 million. The country can no longer sustain itself as an independent nation. The Saeima votes to merge into a Nordic-Baltic federation.' };
+  }
+  if ((ind.publicConfidence ?? 50) < 8) {
+    return { ...state, gameOver: true, gameOverReason: 'Confidence in the future has collapsed. Even the optimists left for Dublin. A passive resignation sets in across the country — and across your cabinet. You step down "for personal reasons" no one quite believes.' };
+  }
+  if ((ind.socialStrain ?? 50) > 90) {
+    return { ...state, gameOver: true, gameOverReason: 'Social strain overflows. A general strike paralyses Riga, then Daugavpils, then everywhere. Your motorcade is rerouted around protesters for the fourth week in a row. The President accepts your resignation "with regret".' };
   }
   if (ind.publicHappiness < 5) {
     return { ...state, gameOver: true, gameOverReason: 'Mass protests erupt across Riga. The government collapses. You are escorted from the Saeima by your own guards. Your portrait will not hang in the presidential gallery.' };

--- a/src/engine/factions.ts
+++ b/src/engine/factions.ts
@@ -1,0 +1,275 @@
+import type { Rng } from './random';
+import { clamp } from './random';
+
+/**
+ * Tropico-style ideological factions — a layer on top of the existing
+ * Saeima party system. Parties live in politics.ts and care about elections;
+ * factions live here and care about every quarter.
+ *
+ * Each faction has a fictional named leader (the "face" of the bloc),
+ * a color, an ideology blurb, and a priority list of indicators they
+ * watch. Their approval drifts passively each quarter based on indicators
+ * AND can be shifted by explicit event-choice reactions.
+ *
+ * Acceptance from the plan: every event card shows leader-portrait reaction
+ * icons that change as you hover over each choice.
+ */
+
+export type FactionId =
+  | 'entrepreneurs'
+  | 'socialDems'
+  | 'natoBloc'
+  | 'reformBloc'
+  | 'identity'
+  | 'green'
+  | 'minority';
+
+export type ReactionLevel = 'love' | 'cheer' | 'meh' | 'frown' | 'rage';
+
+export interface FactionDef {
+  id: FactionId;
+  name: string;
+  shortName: string;
+  leader: string;
+  leaderInitials: string;
+  color: string;
+  ideology: string;
+  /** Indicator keys this faction cares about (positive direction). */
+  caresAboutUp: string[];
+  /** Indicator keys this faction cares about (wants down). */
+  caresAboutDown: string[];
+  /** One-liner the faction publishes when *very* happy. */
+  praiseQuote: string;
+  /** One-liner the faction publishes when *very* unhappy. */
+  angerQuote: string;
+}
+
+export const FACTIONS: FactionDef[] = [
+  {
+    id: 'entrepreneurs',
+    name: 'Entrepreneurs & Investors',
+    shortName: 'ENT',
+    leader: 'Andris Kalniņš',
+    leaderInitials: 'AK',
+    color: '#D4A843',
+    ideology: 'Capital-friendly · low tax · single market',
+    caresAboutUp: ['foreignInvestment', 'techSector', 'gdpGrowth', 'portActivity'],
+    caresAboutDown: ['taxBurden', 'corruptionLevel'],
+    praiseQuote: '"Latvia is finally open for business."',
+    angerQuote: '"My next office will be in Tallinn."',
+  },
+  {
+    id: 'socialDems',
+    name: 'Social Democrats & Unions',
+    shortName: 'SD',
+    leader: 'Ilze Krastiņa',
+    leaderInitials: 'IK',
+    color: '#9C27B0',
+    ideology: 'Welfare · workers\' rights · public services',
+    caresAboutUp: ['healthcareQuality', 'educationQuality', 'socialCohesion', 'publicConfidence'],
+    caresAboutDown: ['unemployment', 'socialStrain'],
+    praiseQuote: '"For once, the government remembers who pays the bills."',
+    angerQuote: '"The strike committee is ready."',
+  },
+  {
+    id: 'natoBloc',
+    name: 'NATO & Security Bloc',
+    shortName: 'NTO',
+    leader: 'Gen. Jānis Ozoliņš (ret.)',
+    leaderInitials: 'JO',
+    color: '#8B0000',
+    ideology: 'Deterrence first · hard border · 3% GDP defense',
+    caresAboutUp: ['militaryReadiness', 'natoRelations', 'borderSecurity', 'cyberDefense'],
+    caresAboutDown: ['russiaRelations'], // they prefer it cold
+    praiseQuote: '"A serious country, at last."',
+    angerQuote: '"We will be remembered for what we did not build."',
+  },
+  {
+    id: 'reformBloc',
+    name: 'Reform & EU Integration Bloc',
+    shortName: 'REF',
+    leader: 'Dr. Liene Vītola',
+    leaderInitials: 'LV',
+    color: '#1B75BB',
+    ideology: 'Rule of law · judicial independence · press freedom',
+    caresAboutUp: ['euStanding', 'mediaTrust', 'educationQuality', 'digitalInfra'],
+    caresAboutDown: ['corruptionLevel'],
+    praiseQuote: '"The institutions are working. Note the date."',
+    angerQuote: '"The European Court will hear about this."',
+  },
+  {
+    id: 'identity',
+    name: 'National Identity & Heritage',
+    shortName: 'NAT',
+    leader: 'Māris Bērziņš',
+    leaderInitials: 'MB',
+    color: '#3D3731',
+    ideology: 'Language · culture · historical memory',
+    caresAboutUp: ['nationalIdentity', 'borderSecurity'],
+    caresAboutDown: ['emigrationRate'],
+    praiseQuote: '"The dainas approve."',
+    angerQuote: '"We are losing the country, quietly."',
+  },
+  {
+    id: 'green',
+    name: 'Green Latvia',
+    shortName: 'GRN',
+    leader: 'Elīna Ozola',
+    leaderInitials: 'EO',
+    color: '#4CAF50',
+    ideology: 'Carbon targets · renewables · EU sustainability',
+    caresAboutUp: ['greenTransition', 'energyIndependence'],
+    caresAboutDown: [],
+    praiseQuote: '"The 2040 target is no longer fiction."',
+    angerQuote: '"You burned the future for one cheap winter."',
+  },
+  {
+    id: 'minority',
+    name: 'Russian-Speaking Citizens',
+    shortName: 'RUS',
+    leader: 'Sergejs Pavlovs',
+    leaderInitials: 'SP',
+    color: '#607D8B',
+    ideology: 'Bilingual services · integration · civic equality',
+    caresAboutUp: ['russianMinorityIntegration', 'socialCohesion'],
+    caresAboutDown: ['socialStrain'],
+    praiseQuote: '"We are citizens, too. And finally treated that way."',
+    angerQuote: '"This town has two halves again. It does not have to."',
+  },
+];
+
+export function getFaction(id: FactionId): FactionDef | undefined {
+  return FACTIONS.find(f => f.id === id);
+}
+
+/** Default approval map — everyone starts middling around 45-55. */
+export function createInitialFactionApproval(): Record<FactionId, number> {
+  return {
+    entrepreneurs: 50,
+    socialDems: 48,
+    natoBloc: 60,
+    reformBloc: 52,
+    identity: 55,
+    green: 45,
+    minority: 38,
+  };
+}
+
+/** Map reaction level to delta. */
+export function reactionDelta(r: ReactionLevel): number {
+  switch (r) {
+    case 'love': return 8;
+    case 'cheer': return 4;
+    case 'meh': return 0;
+    case 'frown': return -4;
+    case 'rage': return -8;
+  }
+}
+
+/** Visual symbol for a reaction (used on event cards). */
+export function reactionSymbol(r: ReactionLevel): string {
+  switch (r) {
+    case 'love': return '💗';
+    case 'cheer': return '👍';
+    case 'meh': return '😐';
+    case 'frown': return '😠';
+    case 'rage': return '🔥';
+  }
+}
+
+/**
+ * Apply explicit faction reactions from a choice.
+ * Pure function — returns new approval map.
+ */
+export function applyFactionReactions(
+  approval: Record<FactionId, number>,
+  reactions: Partial<Record<FactionId, ReactionLevel>>,
+  rng: Rng,
+): Record<FactionId, number> {
+  const next = { ...approval };
+  for (const [id, level] of Object.entries(reactions) as [FactionId, ReactionLevel][]) {
+    const base = reactionDelta(level);
+    const varied = rng.vary(base, 0.2);
+    next[id] = clamp((next[id] ?? 50) + varied, 0, 100);
+  }
+  return next;
+}
+
+/**
+ * Passive drift: each faction's approval drifts each quarter based on
+ * whether their priority indicators are healthy. This is the "ambient"
+ * pressure layer that runs even when no event reaction triggers.
+ *
+ * Cynicism applies a small uniform malus to every faction's drift.
+ */
+export function driftFactionApproval(
+  approval: Record<FactionId, number>,
+  indicators: Record<string, number>,
+  rng: Rng,
+  cynicism: number = 0,
+): Record<FactionId, number> {
+  const next = { ...approval };
+  const cynicismMalus = -Math.min(0.6, cynicism * 0.015);
+  for (const f of FACTIONS) {
+    let drift = 0;
+    for (const k of f.caresAboutUp) {
+      const v = indicators[k] ?? 50;
+      drift += (v - 50) * 0.04;
+    }
+    for (const k of f.caresAboutDown) {
+      const v = indicators[k] ?? 50;
+      drift += (50 - v) * 0.04;
+    }
+    // Add gentle reversion toward 50
+    drift += (50 - next[f.id]) * 0.02;
+    // Cynicism drag
+    drift += cynicismMalus;
+    drift = rng.vary(drift, 0.2);
+    next[f.id] = clamp(next[f.id] + drift, 0, 100);
+  }
+  return next;
+}
+
+/** Apply trait starting biases to faction approval. */
+export function applyTraitFactionBias(
+  approval: Record<FactionId, number>,
+  traitIds: string[],
+): Record<FactionId, number> {
+  const next = { ...approval };
+  // Maps from trait id → faction id offsets.
+  const TRAIT_FACTION: Record<string, Partial<Record<FactionId, number>>> = {
+    technocrat: { entrepreneurs: 5, reformBloc: 3, socialDems: -4 },
+    euroatlanticist: { reformBloc: 12, natoBloc: 8, identity: -10, minority: -3 },
+    populist: { entrepreneurs: -3, reformBloc: -6, socialDems: 4, identity: 6 },
+    crisisManager: { reformBloc: 5, natoBloc: 3 },
+    natoHawk: { natoBloc: 15, identity: 6, socialDems: -5, minority: -8 },
+    balticPragmatist: { entrepreneurs: 4, socialDems: 4, natoBloc: 4, reformBloc: 4, identity: 4, green: 4, minority: 4 },
+  };
+  for (const t of traitIds) {
+    const bias = TRAIT_FACTION[t];
+    if (!bias) continue;
+    for (const [fid, delta] of Object.entries(bias) as [FactionId, number][]) {
+      next[fid] = clamp(next[fid] + delta, 0, 100);
+    }
+  }
+  return next;
+}
+
+/** Whether a faction is in "love"/"crisis" thresholds — drives event triggers. */
+export function factionMood(approval: number): 'love' | 'happy' | 'neutral' | 'unhappy' | 'crisis' {
+  if (approval >= 75) return 'love';
+  if (approval >= 55) return 'happy';
+  if (approval >= 35) return 'neutral';
+  if (approval >= 20) return 'unhappy';
+  return 'crisis';
+}
+
+/** Get current faction quote based on mood. */
+export function factionMoodQuote(f: FactionDef, approval: number): string {
+  const m = factionMood(approval);
+  if (m === 'love') return f.praiseQuote;
+  if (m === 'crisis') return f.angerQuote;
+  if (m === 'happy') return '"Cautiously approving."';
+  if (m === 'unhappy') return '"We have concerns."';
+  return '"Watching closely."';
+}

--- a/src/engine/indicators.ts
+++ b/src/engine/indicators.ts
@@ -20,7 +20,9 @@ export const INDICATORS: IndicatorMeta[] = [
   { key: 'workforceSkill', name: 'Workforce Skills', description: 'Education and skill level of workers', emoji: '🎓', category: 'demographics', format: 'index', min: 0, max: 100, goodDirection: 'up' },
 
   // Society
-  { key: 'publicHappiness', name: 'Public Happiness', description: 'General population satisfaction', emoji: '😊', category: 'society', format: 'index', min: 0, max: 100, goodDirection: 'up' },
+  { key: 'publicHappiness', name: 'Public Happiness', description: 'Aggregate mood — derived from Confidence and Strain', emoji: '😊', category: 'society', format: 'index', min: 0, max: 100, goodDirection: 'up' },
+  { key: 'publicConfidence', name: 'Public Confidence', description: 'Belief the country is heading in the right direction', emoji: '🌅', category: 'society', format: 'index', min: 0, max: 100, goodDirection: 'up' },
+  { key: 'socialStrain', name: 'Social Strain', description: 'Resentment, inequality, daily friction. Lower is better.', emoji: '😤', category: 'society', format: 'index', min: 0, max: 100, goodDirection: 'down' },
   { key: 'healthcareQuality', name: 'Healthcare', description: 'Quality and accessibility of healthcare', emoji: '🏥', category: 'society', format: 'index', min: 0, max: 100, goodDirection: 'up' },
   { key: 'educationQuality', name: 'Education', description: 'Quality of education system', emoji: '📚', category: 'society', format: 'index', min: 0, max: 100, goodDirection: 'up' },
   { key: 'corruptionLevel', name: 'Corruption', description: 'Level of corruption in government and business', emoji: '🕵️', category: 'society', format: 'index', min: 0, max: 100, goodDirection: 'down' },

--- a/src/engine/legacy.ts
+++ b/src/engine/legacy.ts
@@ -1,0 +1,222 @@
+import type { GameState } from './types';
+import { getTrait } from './traits';
+
+/**
+ * Legacy Report — Suzerain/Frostpunk-style "Was it worth it?" verdict.
+ *
+ * Pure function. Reads the final state, assigns an archetype label, and
+ * generates a multi-paragraph historian's verdict.
+ *
+ * Tone: a historian writing 30 years after the player's term ended.
+ * Latvian deadpan, EU memo formality, no judgement — just patterns.
+ */
+
+export interface ArchetypeDef {
+  id: string;
+  label: string;
+  emoji: string;
+  blurb: string;
+  /** Score function — higher means a better fit. Tie-broken alphabetically. */
+  fit: (s: GameState) => number;
+}
+
+const ind = (s: GameState, k: string) => s.indicators[k] ?? 50;
+
+export const ARCHETYPES: ArchetypeDef[] = [
+  {
+    id: 'balticTiger',
+    label: 'The Baltic Tiger',
+    emoji: '🐯',
+    blurb: 'A Premier remembered for sustained growth, healthy budgets, and the smell of new construction. Economists love you. Children may have studied your tenure in school.',
+    fit: (s) =>
+      (ind(s, 'gdp') > 60 ? 30 : 0) +
+      (ind(s, 'gdpGrowth') > 3 ? 20 : 0) +
+      (ind(s, 'foreignInvestment') > 60 ? 15 : 0) +
+      (ind(s, 'techSector') > 55 ? 10 : 0) -
+      (ind(s, 'publicDebt') > 80 ? 25 : 0),
+  },
+  {
+    id: 'brusselsTechnocrat',
+    label: 'The Brussels Technocrat',
+    emoji: '🇪🇺',
+    blurb: 'Quietly competent. Predictably compliant. The country was governed the way an actuarial table is read: line by line. Brussels approved.',
+    fit: (s) =>
+      (ind(s, 'euStanding') > 65 ? 25 : 0) +
+      (ind(s, 'corruptionLevel') < 35 ? 15 : 0) +
+      (ind(s, 'foreignInvestment') > 55 ? 10 : 0) +
+      (ind(s, 'mediaTrust') > 55 ? 5 : 0) -
+      (ind(s, 'publicConfidence') < 40 ? 10 : 0),
+  },
+  {
+    id: 'populistGambler',
+    label: 'The Populist Gambler',
+    emoji: '🎰',
+    blurb: 'A premiership of grand gestures and louder press conferences. Whether it worked depends on which decade you ask, and which voter.',
+    fit: (s) =>
+      (ind(s, 'publicConfidence') > 60 ? 20 : 0) +
+      (ind(s, 'publicDebt') > 70 ? 15 : 0) +
+      (ind(s, 'foreignInvestment') < 45 ? 10 : 0) +
+      (s.traits.includes('populist') ? 15 : 0),
+  },
+  {
+    id: 'cautiousKeeper',
+    label: 'The Cautious Keeper',
+    emoji: '🪙',
+    blurb: 'A safe pair of hands. Nothing collapsed. Nothing soared. The state apparatus is grateful. So is the bond market.',
+    fit: (s) =>
+      (Math.abs(ind(s, 'gdpGrowth') - 2.5) < 1.5 ? 20 : 0) +
+      (ind(s, 'publicDebt') < 50 ? 15 : 0) +
+      (ind(s, 'socialStrain') < 50 ? 10 : 0) +
+      (ind(s, 'corruptionLevel') < 45 ? 5 : 0) -
+      (ind(s, 'foreignInvestment') > 75 ? 10 : 0),
+  },
+  {
+    id: 'forgottenSteward',
+    label: 'The Forgotten Steward',
+    emoji: '🍃',
+    blurb: 'A Premier whose tenure produced few headlines and fewer regrets. History books require a footnote to find you. The footnote is polite.',
+    fit: (s) =>
+      (Math.abs(ind(s, 'gdpGrowth') - 1.5) < 1 ? 15 : 0) +
+      (ind(s, 'publicConfidence') < 55 && ind(s, 'publicConfidence') > 35 ? 10 : 0) +
+      (ind(s, 'socialStrain') < 60 && ind(s, 'socialStrain') > 30 ? 10 : 0),
+  },
+  {
+    id: 'reformer',
+    label: 'The Quiet Reformer',
+    emoji: '⚖️',
+    blurb: 'Institutional change rarely makes the news the day it happens. But the courts, the schools, and the hospitals carry your fingerprints — and citizens, eventually, noticed.',
+    fit: (s) =>
+      (ind(s, 'corruptionLevel') < 30 ? 20 : 0) +
+      (ind(s, 'educationQuality') > 65 ? 15 : 0) +
+      (ind(s, 'healthcareQuality') > 60 ? 15 : 0) +
+      (ind(s, 'mediaTrust') > 55 ? 5 : 0),
+  },
+  {
+    id: 'natoFortress',
+    label: 'The Fortress Builder',
+    emoji: '🛡️',
+    blurb: 'A Premier who treated the eastern border as a permanent fixture of foreign policy — and budgeted accordingly. Allies took note. So did the General Staff.',
+    fit: (s) =>
+      (ind(s, 'militaryReadiness') > 70 ? 20 : 0) +
+      (ind(s, 'natoRelations') > 80 ? 15 : 0) +
+      (ind(s, 'borderSecurity') > 70 ? 10 : 0) +
+      (ind(s, 'cyberDefense') > 65 ? 10 : 0) +
+      (s.traits.includes('natoHawk') ? 10 : 0),
+  },
+  {
+    id: 'greenPivot',
+    label: 'The Green Pivot',
+    emoji: '🌿',
+    blurb: 'Wind turbines on the Kurzeme coast outlived your government. So did the rebates. So did the gentle EU compliments.',
+    fit: (s) =>
+      (ind(s, 'greenTransition') > 65 ? 25 : 0) +
+      (ind(s, 'energyIndependence') > 60 ? 15 : 0) +
+      (ind(s, 'euStanding') > 60 ? 5 : 0),
+  },
+  {
+    id: 'tigerToCub',
+    label: 'The Tiger Cub',
+    emoji: '🐅',
+    blurb: 'The promise was there. The numbers… less so. Tech founders praise you on podcasts. Pensioners praise the previous government.',
+    fit: (s) =>
+      (ind(s, 'techSector') > 60 && ind(s, 'gdp') < 55 ? 25 : 0) +
+      (ind(s, 'foreignInvestment') > 60 ? 10 : 0) -
+      (ind(s, 'healthcareQuality') < 40 ? 10 : 0),
+  },
+  {
+    id: 'lostDecade',
+    label: 'The Lost Decade',
+    emoji: '💀',
+    blurb: 'When the country looks back, it does so unwillingly. Your name appears next to a chapter titled, by consensus, "The Mistake."',
+    fit: (s) =>
+      (ind(s, 'gdp') < 30 ? 30 : 0) +
+      (ind(s, 'population') < 1.6 ? 20 : 0) +
+      (ind(s, 'publicDebt') > 100 ? 15 : 0) +
+      (ind(s, 'publicConfidence') < 25 ? 15 : 0),
+  },
+  {
+    id: 'kingOfTheCoalitions',
+    label: 'The Coalition Whisperer',
+    emoji: '🤝',
+    blurb: 'Your enduring achievement was that the government continued to function. This is not a small thing. It is the only thing seven Latvian Premiers ever managed.',
+    fit: (s) =>
+      (s.parliament.electionHistory.length >= 2 ? 25 : 0) +
+      (s.turn >= 32 ? 15 : 0) +
+      (ind(s, 'publicConfidence') > 50 ? 5 : 0),
+  },
+];
+
+export interface Legacy {
+  archetype: ArchetypeDef;
+  paragraphs: string[];
+  highlights: { label: string; value: string; tone: 'good' | 'bad' | 'neutral' }[];
+}
+
+function paragraphOpener(s: GameState): string {
+  const yrs = s.year - 2025;
+  if (yrs <= 1) return `Your tenure was brief — ${yrs <= 0 ? 'less than a year' : 'one short year'}, but historians have made a small industry of asking what went wrong.`;
+  if (yrs <= 4) return `Your single term — ${yrs} years — sits in the records as a self-contained episode. The pundits still argue about whether it was a beginning, an interruption, or a warning.`;
+  if (yrs <= 8) return `Two terms in office. Long enough to set a direction. Short enough that the next government could change it. They did.`;
+  return `${yrs} years at the helm — an unusual longevity in modern Latvian politics. Whether the country grew tired of you, or simply could not imagine an alternative, is a question for the campaign biographers.`;
+}
+
+function paragraphTraitFlavor(s: GameState): string {
+  const traits = s.traits.map(t => getTrait(t)?.name).filter(Boolean);
+  if (traits.length === 0) return '';
+  if (traits.length === 1) return `You governed as a ${traits[0]} would: with the strengths and the weaknesses of that disposition.`;
+  return `You came to office as a ${traits[0]} and a ${traits[1]}. Cabinet minutes from later years suggest the second label was the more accurate one.`;
+}
+
+function paragraphIndicators(s: GameState): string {
+  const items: string[] = [];
+  if (ind(s, 'gdp') > 60) items.push('the economy grew, in fits and starts, into something modestly proud of itself');
+  else if (ind(s, 'gdp') < 30) items.push('the economy did not grow, and the bond markets noticed');
+  if (ind(s, 'population') < 1.6) items.push('the demographic curve continued downward, despite three press conferences and a hashtag');
+  if (ind(s, 'population') > 1.95) items.push('the demographic decline was, against all forecasts, arrested');
+  if (ind(s, 'natoRelations') > 80) items.push('NATO partners listed Latvia as "exemplary" — a word used sparingly in Brussels');
+  if (ind(s, 'russiaRelations') < 10) items.push('the eastern border remained, by official terminology, "active"');
+  if (ind(s, 'corruptionLevel') < 30) items.push('KNAB earned a reputation for actually catching people');
+  if (ind(s, 'corruptionLevel') > 60) items.push('KNAB earned a reputation for opening "preliminary inquiries" that never quite finished');
+  if (ind(s, 'techSector') > 60) items.push('Riga\'s startup scene held its own against Tallinn — and on the right Wednesday, beat it');
+  if (ind(s, 'greenTransition') > 60) items.push('the wind turbines outlasted the government, as wind turbines tend to');
+  if (ind(s, 'healthcareQuality') > 60) items.push('hospitals stopped appearing at the bottom of EU rankings — a generational achievement');
+  if (items.length === 0) return 'The indicators moved within tolerances. The country, in the language of the briefings, "trended sideways".';
+  return `Under your watch, ${items.slice(0, 4).join('; ')}.`;
+}
+
+function paragraphReason(s: GameState): string {
+  if (!s.gameOverReason) return 'You left office on your own terms, which is itself a kind of victory in Latvian politics.';
+  return `The exit, when it came, was unmistakable: ${s.gameOverReason}`;
+}
+
+function paragraphLast(s: GameState, a: ArchetypeDef): string {
+  return `History, in its slow way, has settled on a label. ${a.blurb}`;
+}
+
+export function generateLegacy(state: GameState): Legacy {
+  // Pick best-fitting archetype, deterministically
+  const ranked = [...ARCHETYPES]
+    .map(a => ({ a, score: a.fit(state) }))
+    .sort((x, y) => y.score - x.score || x.a.id.localeCompare(y.a.id));
+  const archetype = ranked[0].a;
+
+  const paragraphs = [
+    paragraphOpener(state),
+    paragraphTraitFlavor(state),
+    paragraphIndicators(state),
+    paragraphReason(state),
+    paragraphLast(state, archetype),
+  ].filter(Boolean);
+
+  const i = (k: string) => state.indicators[k] ?? 0;
+  const highlights: Legacy['highlights'] = [
+    { label: 'Final GDP', value: `€${i('gdp').toFixed(0)}B`, tone: i('gdp') > 60 ? 'good' : i('gdp') < 30 ? 'bad' : 'neutral' },
+    { label: 'Population', value: `${i('population').toFixed(2)}M`, tone: i('population') > 1.9 ? 'good' : i('population') < 1.5 ? 'bad' : 'neutral' },
+    { label: 'Public Debt', value: `${i('publicDebt').toFixed(0)}%`, tone: i('publicDebt') < 50 ? 'good' : i('publicDebt') > 90 ? 'bad' : 'neutral' },
+    { label: 'NATO ties', value: `${i('natoRelations').toFixed(0)}`, tone: i('natoRelations') > 70 ? 'good' : i('natoRelations') < 40 ? 'bad' : 'neutral' },
+    { label: 'Confidence', value: `${i('publicConfidence').toFixed(0)}`, tone: i('publicConfidence') > 60 ? 'good' : i('publicConfidence') < 35 ? 'bad' : 'neutral' },
+    { label: 'Strain', value: `${i('socialStrain').toFixed(0)}`, tone: i('socialStrain') < 40 ? 'good' : i('socialStrain') > 65 ? 'bad' : 'neutral' },
+  ];
+
+  return { archetype, paragraphs, highlights };
+}

--- a/src/engine/magnitudes.ts
+++ b/src/engine/magnitudes.ts
@@ -1,0 +1,45 @@
+import { INDICATORS } from './indicators';
+
+/**
+ * Reigns-style qualitative magnitude labels.
+ * Numbers stay in the engine — players only see direction + size word.
+ *
+ * Magnitude is computed relative to the indicator's full range so a +3 GDP
+ * (range 15-120, ~3% of range) is "Notable", while +3 to a 0-100 index
+ * (3% of range) is also "Notable". This keeps the language calibrated.
+ */
+export type Magnitude = 'Slight' | 'Notable' | 'Major' | 'Severe';
+
+export function magnitudeOf(indicatorKey: string, delta: number): Magnitude {
+  const abs = Math.abs(delta);
+  const meta = INDICATORS.find(i => i.key === indicatorKey);
+  const range = meta ? meta.max - meta.min : 100;
+  const pct = (abs / range) * 100;
+  if (pct < 1.2) return 'Slight';
+  if (pct < 5) return 'Notable';
+  if (pct < 12) return 'Major';
+  return 'Severe';
+}
+
+/** Short qualitative delay label — "Now", "Soon", "Later", "Long-term". */
+export type DelayLabel = 'Now' | 'Soon' | 'Later' | 'Long-term';
+
+export function delayLabelOf(delayTurns: number): DelayLabel {
+  if (delayTurns <= 0) return 'Now';
+  if (delayTurns <= 2) return 'Soon';
+  if (delayTurns <= 5) return 'Later';
+  return 'Long-term';
+}
+
+/**
+ * Colour tier for a magnitude — used by the UI to scale visual weight.
+ * Slight = whisper, Severe = shout.
+ */
+export function magnitudeWeight(m: Magnitude): number {
+  switch (m) {
+    case 'Slight': return 1;
+    case 'Notable': return 2;
+    case 'Major': return 3;
+    case 'Severe': return 4;
+  }
+}

--- a/src/engine/manifesto.ts
+++ b/src/engine/manifesto.ts
@@ -1,0 +1,153 @@
+import type { GameState } from './types';
+
+/**
+ * Democracy 4-style manifesto system.
+ *
+ * Before taking office (and after every election win), the player makes
+ * 3 promises from a curated list. Each promise has a measurable target.
+ * At the next election, kept promises bump the cynicism meter down a bit,
+ * broken promises raise it. Cynicism is permanent — it never fully decays.
+ *
+ * High cynicism makes every faction harder to satisfy (a flat malus on
+ * passive faction drift).
+ */
+
+export interface PromiseDef {
+  id: string;
+  title: string;
+  description: string;
+  /** Indicator key the promise tracks. */
+  indicator: string;
+  /** "above" or "below" the target value. */
+  comparison: 'above' | 'below';
+  /** Target value. */
+  target: number;
+  /** Faction(s) most pleased if delivered. */
+  resonates: string[];
+}
+
+export const PROMISES: PromiseDef[] = [
+  {
+    id: 'unemployment-low',
+    title: 'Unemployment below 6%',
+    description: 'A working country. Pension contributions, less drama.',
+    indicator: 'unemployment',
+    comparison: 'below',
+    target: 6,
+    resonates: ['socialDems', 'entrepreneurs'],
+  },
+  {
+    id: 'gdp-grow',
+    title: 'GDP growth above 3% annually',
+    description: 'Out-perform the Estonians, just this once.',
+    indicator: 'gdpGrowth',
+    comparison: 'above',
+    target: 3,
+    resonates: ['entrepreneurs'],
+  },
+  {
+    id: 'debt-floor',
+    title: 'Public debt under 50% of GDP',
+    description: 'Fiscal discipline. Brussels will notice. So will the bond market.',
+    indicator: 'publicDebt',
+    comparison: 'below',
+    target: 50,
+    resonates: ['reformBloc', 'entrepreneurs'],
+  },
+  {
+    id: 'defense-three',
+    title: 'Defence spending sustained ≥ 2.5% GDP',
+    description: 'A serious country. The General Staff will sleep slightly better.',
+    indicator: 'militaryReadiness',
+    comparison: 'above',
+    target: 65,
+    resonates: ['natoBloc'],
+  },
+  {
+    id: 'healthcare-fix',
+    title: 'Healthcare quality above 55',
+    description: 'No more last place. Just second-to-last.',
+    indicator: 'healthcareQuality',
+    comparison: 'above',
+    target: 55,
+    resonates: ['socialDems'],
+  },
+  {
+    id: 'emigration-down',
+    title: 'Cut emigration rate below 40',
+    description: 'They can keep Dublin. We want our nurses back.',
+    indicator: 'emigrationRate',
+    comparison: 'below',
+    target: 40,
+    resonates: ['identity', 'socialDems'],
+  },
+  {
+    id: 'corruption-down',
+    title: 'Corruption index below 35',
+    description: 'KNAB does more than open inquiries. It finishes them.',
+    indicator: 'corruptionLevel',
+    comparison: 'below',
+    target: 35,
+    resonates: ['reformBloc'],
+  },
+  {
+    id: 'green-target',
+    title: 'Green transition above 60',
+    description: 'Carbon targets met. EU pats on the back received.',
+    indicator: 'greenTransition',
+    comparison: 'above',
+    target: 60,
+    resonates: ['green'],
+  },
+  {
+    id: 'tech-sector',
+    title: 'Tech sector index above 60',
+    description: 'A real Silicon Baltic, not a press release.',
+    indicator: 'techSector',
+    comparison: 'above',
+    target: 60,
+    resonates: ['entrepreneurs', 'reformBloc'],
+  },
+];
+
+export interface PromiseRecord {
+  promiseId: string;
+  termIndex: number;
+  fulfilled?: boolean;
+}
+
+export function isPromiseFulfilled(p: PromiseDef, state: GameState): boolean {
+  const v = state.indicators[p.indicator] ?? 0;
+  return p.comparison === 'above' ? v >= p.target : v <= p.target;
+}
+
+/**
+ * Evaluate all current-term promises and return the delta to apply to
+ * the cynicism meter, plus per-promise kept/broken records.
+ *
+ * Fulfilled promise: -3 cynicism, capped at 0.
+ * Broken promise: +5 cynicism.
+ */
+export function evaluatePromises(
+  promises: PromiseRecord[],
+  state: GameState,
+  currentTermIndex: number,
+): { cynicismDelta: number; resolved: PromiseRecord[] } {
+  let cynicismDelta = 0;
+  const resolved: PromiseRecord[] = [];
+  for (const r of promises) {
+    if (r.termIndex !== currentTermIndex || r.fulfilled !== undefined) {
+      resolved.push(r);
+      continue;
+    }
+    const def = PROMISES.find(p => p.id === r.promiseId);
+    if (!def) {
+      resolved.push(r);
+      continue;
+    }
+    const fulfilled = isPromiseFulfilled(def, state);
+    cynicismDelta += fulfilled ? -3 : 5;
+    resolved.push({ ...r, fulfilled });
+  }
+  return { cynicismDelta, resolved };
+}

--- a/src/engine/ministers.ts
+++ b/src/engine/ministers.ts
@@ -1,0 +1,256 @@
+import type { GameEvent, EventCategory } from './types';
+import type { Rng } from './random';
+import type { FactionId } from './factions';
+
+/**
+ * Cabinet ministers — persistent NPCs with biases.
+ *
+ * Suzerain-style: ministers have agendas, sometimes give bad advice that
+ * serves their interests. Reading their bias becomes a meta-skill.
+ *
+ * Each minister belongs to a faction (so they "represent" that bloc in
+ * cabinet) and has a primary domain. When an event is `highStakes`, the
+ * Advisor Debate panel pulls 2-3 ministers whose domains best match the
+ * category and shows their character-voiced one-liners.
+ */
+
+export type MinisterPortfolio =
+  | 'finance'
+  | 'foreign'
+  | 'defense'
+  | 'health'
+  | 'interior'
+  | 'education';
+
+export interface MinisterDef {
+  id: string;
+  name: string;
+  initials: string;
+  portfolio: MinisterPortfolio;
+  title: string;
+  factionId: FactionId;
+  /** Short ideological bias label shown next to their name. */
+  biasLabel: string;
+  /** Color (inherits faction color in UI). */
+  // Lines per event category — picked at random for variety.
+  lines: Partial<Record<EventCategory | 'default', string[]>>;
+}
+
+export const MINISTERS: MinisterDef[] = [
+  {
+    id: 'finance-kalnins',
+    name: 'Andris Kalniņš',
+    initials: 'AK',
+    portfolio: 'finance',
+    title: 'Minister of Finance',
+    factionId: 'entrepreneurs',
+    biasLabel: 'Fiscally Conservative',
+    lines: {
+      economy: [
+        '"We can afford this. We always can — by cutting elsewhere."',
+        '"The deficit is a feeling, not a number. Mostly."',
+        '"Brussels will frown. Brussels frowns at oxygen. Proceed."',
+      ],
+      society: [
+        '"Social spending? Tell me which envelope we are robbing this time."',
+        '"Healthcare is a cost centre. I have said this before."',
+      ],
+      crisis: [
+        '"Open the rainy-day fund. This is the rainy day. Probably."',
+      ],
+      diplomacy: [
+        '"Trade with anyone. Money is agnostic about borders."',
+      ],
+      petition: [
+        '"Pensioners voting once is cheaper than pensioners voting twice."',
+      ],
+      default: [
+        '"Has anyone modelled the second-order fiscal impact? No? Of course."',
+      ],
+    },
+  },
+  {
+    id: 'foreign-lazdins',
+    name: 'Pēteris Lazdiņš',
+    initials: 'PL',
+    portfolio: 'foreign',
+    title: 'Minister of Foreign Affairs',
+    factionId: 'reformBloc',
+    biasLabel: 'Brussels-Aligned',
+    lines: {
+      diplomacy: [
+        '"Brussels has views. They are usually right, and always loud."',
+        '"Estonia did this last year. We can do it badly, or do it after them."',
+      ],
+      security: [
+        '"NATO partners are watching. They are always watching."',
+        '"A measured response is, by definition, a measured response."',
+      ],
+      economy: [
+        '"This will play well in Berlin. Less well in Warsaw."',
+      ],
+      crisis: [
+        '"Crisis communication first. Substance later."',
+      ],
+      default: [
+        '"It depends entirely on how this lands in the European Council."',
+      ],
+    },
+  },
+  {
+    id: 'defense-ozolins',
+    name: 'Gen. Jānis Ozoliņš (ret.)',
+    initials: 'JO',
+    portfolio: 'defense',
+    title: 'Minister of Defence',
+    factionId: 'natoBloc',
+    biasLabel: 'NATO Hawk',
+    lines: {
+      security: [
+        '"We trained for this. The exercise scripts also said \'unprecedented\'."',
+        '"Three per cent of GDP. That is the floor."',
+      ],
+      diplomacy: [
+        '"Talk if you like. The eastern brigade stays on alert either way."',
+      ],
+      crisis: [
+        '"Calm panic, Premier. We rehearsed this. The press did not."',
+      ],
+      economy: [
+        '"Defence procurement is also industrial policy. Look at Finland."',
+      ],
+      default: [
+        '"Strategic depth, Premier. Always strategic depth."',
+      ],
+    },
+  },
+  {
+    id: 'health-krumina',
+    name: 'Dr. Anna Krūmiņa',
+    initials: 'AK',
+    portfolio: 'health',
+    title: 'Minister of Health & Social Affairs',
+    factionId: 'socialDems',
+    biasLabel: 'Centre-Left',
+    lines: {
+      society: [
+        '"We are last in the EU. Again. Words stopped helping."',
+        '"If we cut transfers we lose half of Latgale by Q4. Please."',
+      ],
+      economy: [
+        '"A healthy workforce is also a workforce. Try and remember that."',
+      ],
+      crisis: [
+        '"The hospital is the first place people look at a government."',
+      ],
+      petition: [
+        '"They are not signing for fun. They are tired."',
+      ],
+      default: [
+        '"Whatever you decide, the queue at Stradiņš grew during this meeting."',
+      ],
+    },
+  },
+  {
+    id: 'interior-berzins',
+    name: 'Māris Bērziņš',
+    initials: 'MB',
+    portfolio: 'interior',
+    title: 'Minister of the Interior',
+    factionId: 'identity',
+    biasLabel: 'Nationalist-Conservative',
+    lines: {
+      security: [
+        '"Border integrity is identity. The two cannot be separated."',
+      ],
+      society: [
+        '"What we tolerate, we eventually become."',
+      ],
+      diplomacy: [
+        '"Negotiate with Moscow if you must. Do not call it dialogue."',
+      ],
+      culture: [
+        '"The song festival starts at sunrise. We rehearse the country, too."',
+      ],
+      crisis: [
+        '"Order first, Premier. Sympathy after."',
+      ],
+      default: [
+        '"There is a Latvian way to do this. It is usually slower and tidier."',
+      ],
+    },
+  },
+  {
+    id: 'education-vitola',
+    name: 'Dr. Liene Vītola',
+    initials: 'LV',
+    portfolio: 'education',
+    title: 'Minister of Education, Science & Culture',
+    factionId: 'reformBloc',
+    biasLabel: 'Reform Liberal',
+    lines: {
+      society: [
+        '"Education compounds. So does its neglect."',
+      ],
+      science: [
+        '"R&D is patient money. Patience is in short supply."',
+        '"MikroTīkls did not happen by accident. Or by ministry."',
+      ],
+      economy: [
+        '"This will work if the universities are still here in 2032."',
+      ],
+      culture: [
+        '"Culture is also industry. The Estonians figured this out faster."',
+      ],
+      default: [
+        '"A footnote: the constitution requires us to mention universities."',
+      ],
+    },
+  },
+];
+
+export function getMinister(id: string): MinisterDef | undefined {
+  return MINISTERS.find(m => m.id === id);
+}
+
+const CATEGORY_PORTFOLIOS: Record<EventCategory, MinisterPortfolio[]> = {
+  economy: ['finance', 'foreign', 'education'],
+  security: ['defense', 'foreign', 'interior'],
+  society: ['health', 'education', 'interior'],
+  diplomacy: ['foreign', 'defense', 'finance'],
+  science: ['education', 'finance'],
+  crisis: ['defense', 'health', 'interior'],
+  environment: ['education', 'finance', 'interior'],
+  culture: ['interior', 'education'],
+  petition: ['health', 'interior', 'finance'],
+};
+
+/**
+ * Pick 2-3 ministers for the advisor debate, biased toward event category.
+ * Stable for a given (seed, eventId, turn).
+ */
+export function pickDebatePanel(event: GameEvent, rng: Rng): MinisterDef[] {
+  const preferred = CATEGORY_PORTFOLIOS[event.category] ?? ['finance', 'foreign', 'health'];
+  const chosen: MinisterDef[] = [];
+  for (const port of preferred) {
+    const m = MINISTERS.find(x => x.portfolio === port);
+    if (m && !chosen.includes(m)) chosen.push(m);
+    if (chosen.length >= 3) break;
+  }
+  // Backfill with random ministers
+  if (chosen.length < 2) {
+    const remaining = MINISTERS.filter(m => !chosen.includes(m));
+    rng.shuffle(remaining);
+    for (const m of remaining) {
+      chosen.push(m);
+      if (chosen.length >= 2) break;
+    }
+  }
+  return chosen.slice(0, 3);
+}
+
+/** Pick an in-character line from a minister for the given event. */
+export function ministerLineFor(m: MinisterDef, event: GameEvent, rng: Rng): string {
+  const pool = m.lines[event.category] ?? m.lines.default ?? ['"No comment."'];
+  return rng.pick(pool);
+}

--- a/src/engine/newsfeed.ts
+++ b/src/engine/newsfeed.ts
@@ -295,19 +295,26 @@ export function generateHeadlines(
     if (final.length >= 5) break;
   }
 
-  // Ensure at least 3
-  while (final.length < 3 && pool.length > 0) {
-    const fallback = `${OUTLET_VOICES.radioJuris}: ${rng.pick([
-      'Latvia: still here.',
-      'The trams ran. Mostly.',
-      'A pothole on Brīvības iela has its own Twitter account now.',
-    ])}`;
-    if (!seen.has(fallback)) {
-      seen.add(fallback);
-      final.push(fallback);
-    } else {
-      break;
+  // Ensure we always return at least 3 headlines — pad with a deterministic
+  // ambient line from the radio commentator.
+  const FALLBACKS = [
+    'Latvia: still here.',
+    'The trams ran. Mostly.',
+    'A pothole on Brīvības iela has its own Twitter account now.',
+    'A statement is forthcoming. The statement will be measured.',
+    'The trade balance moved. Economists nodded.',
+    'No protests today. Pundits suspect this is itself suspicious.',
+  ];
+  let fallbackIdx = 0;
+  while (final.length < 3) {
+    const text = FALLBACKS[fallbackIdx % FALLBACKS.length];
+    fallbackIdx++;
+    const line = `${OUTLET_VOICES.radioJuris}: ${text}`;
+    if (!seen.has(line)) {
+      seen.add(line);
+      final.push(line);
     }
+    if (fallbackIdx > FALLBACKS.length * 2) break;
   }
 
   return final;

--- a/src/engine/newsfeed.ts
+++ b/src/engine/newsfeed.ts
@@ -1,0 +1,314 @@
+import type { GameState, GameEvent } from './types';
+import type { Rng } from './random';
+
+/**
+ * Procedural Tropico-style newsfeed.
+ *
+ * Pure function: given the post-resolution state and the decisions, return
+ * 3-5 short headlines that comment on the quarter. Zero engine impact —
+ * purely flavour, but it transforms the *feel* of every turn.
+ *
+ * Voice rules (per Tone Bible):
+ * - Latvian deadpan + Soviet bureaucratic absurdism + EU memo formality.
+ * - Civil servants speak jargon. Citizens speak plainly and grumpily.
+ * - Pick on every faction equally.
+ * - References: Dublin, Riga, Daugavpils, Liepāja, Latgale, amber, song festivals, "the eternal weather".
+ */
+
+interface HeadlineTemplate {
+  outlet: string;
+  text: string;
+}
+
+// Outlet voices — each has a distinct character.
+const OUTLET_VOICES = {
+  delfi: 'DELFI.lv',
+  dienasBizness: 'Dienas Bizness',
+  lsm: 'LSM.lv',
+  tvnetComment: 'TVNET comments',
+  radioJuris: 'Radio 3 — "Juris on the Hour"',
+  brusselsMemo: 'Brussels memo',
+  diaspora: 'Latvians in Dublin (group chat)',
+  rigaCab: 'Riga taxi driver (overheard)',
+  pensioner: 'Letter to LR1',
+} as const;
+
+type OutletKey = keyof typeof OUTLET_VOICES;
+
+// Decision-reactive headlines. Triggered by indicator deltas.
+const REACTIVE_HEADLINES: Array<{
+  when: (delta: number, key: string) => boolean;
+  templates: Array<[OutletKey, string]>;
+}> = [
+  // Strong positive economy
+  {
+    when: (d, k) => k === 'gdp' && d > 0.5,
+    templates: [
+      ['dienasBizness', 'GDP ticks up again. Cautiously optimistic editorial follows.'],
+      ['rigaCab', 'They say the economy is growing. Then why my fare to Mežaparks is the same as Berlin?'],
+    ],
+  },
+  {
+    when: (d, k) => k === 'gdp' && d < -0.5,
+    templates: [
+      ['dienasBizness', 'Quarterly GDP slip prompts the usual ministry statement about "structural headwinds".'],
+      ['radioJuris', 'GDP down again. Juris: "I have no idea what GDP is, but it sounds worse than last week."'],
+    ],
+  },
+  // Unemployment
+  {
+    when: (d, k) => k === 'unemployment' && d < -0.5,
+    templates: [
+      ['lsm', 'Unemployment falls. Three op-eds debate whether this is real or "definitional".'],
+      ['pensioner', '"Finally my grandson got a job. Even if it is in a call centre."'],
+    ],
+  },
+  {
+    when: (d, k) => k === 'unemployment' && d > 0.5,
+    templates: [
+      ['delfi', 'Joblessness rises. State Employment Agency promises "active measures".'],
+      ['diaspora', 'New arrivals in Dublin this week. Welcome group chat now at 4,891.'],
+    ],
+  },
+  // Healthcare
+  {
+    when: (d, k) => k === 'healthcareQuality' && d > 0.5,
+    templates: [
+      ['lsm', 'Health Ministry announces hospital wait times "improving in pilot regions".'],
+      ['pensioner', '"Got a doctor appointment in three weeks instead of three months. Progress!"'],
+    ],
+  },
+  {
+    when: (d, k) => k === 'healthcareQuality' && d < -0.5,
+    templates: [
+      ['delfi', 'Latvia ranks last in EU healthcare again. Health Minister: "We are aware of this."'],
+      ['tvnetComment', '"At this rate we will be importing Estonian doctors. Imagine."'],
+    ],
+  },
+  // Emigration
+  {
+    when: (d, k) => k === 'emigrationRate' && d > 0.5,
+    templates: [
+      ['diaspora', 'Dublin Latvian community welcomes another shift. Pierogi night at the Liberties pub on Friday.'],
+      ['rigaCab', '"My nephew is gone. To Hamburg this time. They keep finding new cities."'],
+    ],
+  },
+  {
+    when: (d, k) => k === 'emigrationRate' && d < -0.5,
+    templates: [
+      ['lsm', 'Return migration numbers tick up. Demographers urge "measured optimism".'],
+      ['delfi', 'For the first time in years, more Latvians moved back than left. Cautious champagne in the ministries.'],
+    ],
+  },
+  // Russia relations very low
+  {
+    when: (d, k) => k === 'russiaRelations' && d < -0.5,
+    templates: [
+      ['brusselsMemo', 'Council notes "renewed concerns" on the eastern frontier. Translation: more meetings.'],
+      ['radioJuris', 'Juris: "Russia is angry. In other news, the sun rose."'],
+    ],
+  },
+  // NATO relations strong
+  {
+    when: (d, k) => k === 'natoRelations' && d > 0.5,
+    templates: [
+      ['brusselsMemo', 'Latvia "remains a model member-state on burden-sharing." Polite applause in Brussels.'],
+      ['dienasBizness', 'Defence contractors raise quarterly guidance. Coincidence, surely.'],
+    ],
+  },
+  // Tech sector growth
+  {
+    when: (d, k) => k === 'techSector' && d > 0.5,
+    templates: [
+      ['dienasBizness', 'Riga startup raises Series B. The founder is 24. We are all the founder is 24.'],
+      ['delfi', 'MikroTīkls-adjacent fintech announces 200 jobs. CV pile already at 4,000.'],
+    ],
+  },
+  // Corruption rising
+  {
+    when: (d, k) => k === 'corruptionLevel' && d > 0.5,
+    templates: [
+      ['delfi', 'KNAB opens "preliminary inquiries". Translation: a procurement file disappeared again.'],
+      ['tvnetComment', '"I am shocked. SHOCKED. To find gambling on these premises."'],
+    ],
+  },
+  // Birth rate moving
+  {
+    when: (d, k) => k === 'birthRate' && d > 0.5,
+    templates: [
+      ['pensioner', '"I saw three prams in Vērmanes today. Three! Could be a sign."'],
+      ['lsm', 'Birth rate inches up. Demographers: "Statistically irrelevant, but spiritually encouraging."'],
+    ],
+  },
+  // Green transition
+  {
+    when: (d, k) => k === 'greenTransition' && d > 0.5,
+    templates: [
+      ['brusselsMemo', 'Latvia "broadly on track" for 2030 targets. The word "broadly" is doing heavy lifting.'],
+      ['delfi', 'Another wind farm in Kurzeme. The locals are split: "noise" vs. "income".'],
+    ],
+  },
+  // Public confidence up
+  {
+    when: (d, k) => k === 'publicConfidence' && d > 1,
+    templates: [
+      ['radioJuris', '"People feel hopeful," says vox-pop. The cameraman finds three more who disagree."'],
+      ['pensioner', '"For once, my newspaper does not make me angry over breakfast."'],
+    ],
+  },
+  // Social strain up
+  {
+    when: (d, k) => k === 'socialStrain' && d > 1,
+    templates: [
+      ['tvnetComment', '"500 likes on a meme about the price of milk. Times are not great."'],
+      ['rigaCab', '"Everyone is tired. I am tired. The traffic light is tired."'],
+    ],
+  },
+];
+
+// Ambient headlines — fire when state matches but unrelated to deltas.
+const AMBIENT_HEADLINES: Array<{
+  when: (s: GameState) => boolean;
+  templates: Array<[OutletKey, string]>;
+}> = [
+  {
+    when: (s) => s.indicators.publicConfidence > 65 && s.indicators.socialStrain < 35,
+    templates: [
+      ['lsm', 'A government that survives a full quarter without scandal. Political historians take notes.'],
+      ['radioJuris', '"Everyone seems… fine? Suspicious."'],
+    ],
+  },
+  {
+    when: (s) => s.indicators.population < 1.6,
+    templates: [
+      ['delfi', 'Census update: village of Mērsrags now smaller than its WhatsApp group.'],
+      ['diaspora', 'Dublin Latvian football tournament: 14 teams. Riga league: 9.'],
+    ],
+  },
+  {
+    when: (s) => s.indicators.gdpGrowth > 4,
+    templates: [
+      ['dienasBizness', 'Economists revise growth forecast upward. They will revise it back down by Q3.'],
+    ],
+  },
+  {
+    when: (s) => s.indicators.gdpGrowth < -1,
+    templates: [
+      ['dienasBizness', 'Recession word now used in headlines. Government prefers "growth correction".'],
+    ],
+  },
+  {
+    when: (s) => s.indicators.foreignInvestment > 70,
+    templates: [
+      ['brusselsMemo', 'Latvia "increasingly attractive to capital." Estonia adds an asterisk.'],
+    ],
+  },
+  {
+    when: (s) => s.indicators.corruptionLevel > 60,
+    templates: [
+      ['delfi', 'KNAB raids three ministries on the same morning. "Coincidence", says spokesperson.'],
+    ],
+  },
+];
+
+// Seasonal flavour — keyed to quarter.
+const SEASONAL: Record<number, Array<[OutletKey, string]>> = {
+  1: [
+    ['rigaCab', '"Winter again. The eternal winter."'],
+    ['radioJuris', 'Snowfall report: yes.'],
+  ],
+  2: [
+    ['lsm', 'Song festival rehearsals begin. National identity index rises automatically.'],
+    ['delfi', '"Five degrees and the parks are full." — every Latvian, in May.'],
+  ],
+  3: [
+    ['pensioner', '"Mushroom season was good. Politics — less so."'],
+    ['radioJuris', 'July traffic on the Jūrmala road: still bad. Some traditions endure.'],
+  ],
+  4: [
+    ['brusselsMemo', 'End-of-year fiscal review. Latvia "comfortably median."'],
+    ['rigaCab', '"Dark by 4pm. Spirits low. Coffee strong."'],
+  ],
+};
+
+function fmt(outlet: OutletKey, text: string): HeadlineTemplate {
+  return { outlet: OUTLET_VOICES[outlet], text };
+}
+
+/**
+ * Generate 3-5 headlines for the quarter. Stable for a given (seed, turn).
+ */
+export function generateHeadlines(
+  state: GameState,
+  _decisions: { event: GameEvent; choiceIndex: number }[],
+  indicatorsBefore: Record<string, number>,
+  rng: Rng,
+): string[] {
+  const pool: HeadlineTemplate[] = [];
+
+  // 1. Reactive headlines from biggest indicator moves
+  const deltas = Object.keys(state.indicators)
+    .map(k => ({ key: k, delta: state.indicators[k] - (indicatorsBefore[k] ?? state.indicators[k]) }))
+    .filter(d => Math.abs(d.delta) > 0.1)
+    .sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta))
+    .slice(0, 6);
+
+  for (const { key, delta } of deltas) {
+    for (const rule of REACTIVE_HEADLINES) {
+      if (rule.when(delta, key)) {
+        const [outlet, text] = rng.pick(rule.templates);
+        pool.push(fmt(outlet, text));
+        break;
+      }
+    }
+  }
+
+  // 2. Ambient headlines if applicable
+  for (const rule of AMBIENT_HEADLINES) {
+    if (rule.when(state) && rng.next() < 0.4) {
+      const [outlet, text] = rng.pick(rule.templates);
+      pool.push(fmt(outlet, text));
+    }
+  }
+
+  // 3. Seasonal flavour — one per quarter, 50% chance
+  const seasonalSet = SEASONAL[state.quarter] ?? [];
+  if (seasonalSet.length > 0 && rng.next() < 0.5) {
+    const [outlet, text] = rng.pick(seasonalSet);
+    pool.push(fmt(outlet, text));
+  }
+
+  // 4. Catch-all if pool is empty
+  if (pool.length === 0) {
+    pool.push(fmt('radioJuris', 'A quiet quarter. Juris: "I do not trust quiet quarters."'));
+    pool.push(fmt('rigaCab', '"Everything is fine. That is what worries me."'));
+  }
+
+  // Dedupe + cap at 5
+  const seen = new Set<string>();
+  const final: string[] = [];
+  for (const h of pool) {
+    const key = `${h.outlet}|${h.text}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    final.push(`${h.outlet}: ${h.text}`);
+    if (final.length >= 5) break;
+  }
+
+  // Ensure at least 3
+  while (final.length < 3 && pool.length > 0) {
+    const fallback = `${OUTLET_VOICES.radioJuris}: ${rng.pick([
+      'Latvia: still here.',
+      'The trams ran. Mostly.',
+      'A pothole on Brīvības iela has its own Twitter account now.',
+    ])}`;
+    if (!seen.has(fallback)) {
+      seen.add(fallback);
+      final.push(fallback);
+    } else {
+      break;
+    }
+  }
+
+  return final;
+}

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -25,7 +25,9 @@ export function createInitialState(seed?: number): GameState {
     workforceSkill: 52,   // Decent but brain drain hurts
 
     // Society
-    publicHappiness: 45,  // Mid-range
+    publicHappiness: 45,  // Derived from Confidence + Strain (kept for back-compat with events)
+    publicConfidence: 45, // "Is the country heading the right way?"
+    socialStrain: 50,     // "Does daily life feel hard?" (lower is better)
     healthcareQuality: 35, // Worst-ranked in EU historically
     educationQuality: 58, // University system decent
     corruptionLevel: 42,  // CPI 59/100 → inverted
@@ -68,5 +70,7 @@ export function createInitialState(seed?: number): GameState {
     firedOneTimeEvents: new Set(),
     parliament: createInitialParliament(),
     ratings: calculateRatings(indicators),
+    traits: [],
+    pendingEchoes: [],
   };
 }

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -2,6 +2,9 @@ import { GameState } from './types';
 import { INDICATORS } from './indicators';
 import { createInitialParliament, calculateRatings } from './politics';
 import { createInitialFactionApproval } from './factions';
+import { createInitialConstitution } from './constitution';
+import { createInitialSuperpowers } from './superpowers';
+import { createInitialDecrees } from './decrees';
 
 /** Latvia 2025 baseline starting state */
 export function createInitialState(seed?: number): GameState {
@@ -76,5 +79,10 @@ export function createInitialState(seed?: number): GameState {
     factionApproval: createInitialFactionApproval(),
     promises: [],
     cynicism: 0,
+    constitution: createInitialConstitution(),
+    activeArcs: [],
+    completedArcs: new Set(),
+    superpowers: createInitialSuperpowers(),
+    decrees: createInitialDecrees(),
   };
 }

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -1,6 +1,7 @@
 import { GameState } from './types';
 import { INDICATORS } from './indicators';
 import { createInitialParliament, calculateRatings } from './politics';
+import { createInitialFactionApproval } from './factions';
 
 /** Latvia 2025 baseline starting state */
 export function createInitialState(seed?: number): GameState {
@@ -72,5 +73,8 @@ export function createInitialState(seed?: number): GameState {
     ratings: calculateRatings(indicators),
     traits: [],
     pendingEchoes: [],
+    factionApproval: createInitialFactionApproval(),
+    promises: [],
+    cynicism: 0,
   };
 }

--- a/src/engine/superpowers.ts
+++ b/src/engine/superpowers.ts
@@ -1,0 +1,330 @@
+import type { Rng } from './random';
+
+/**
+ * Tropico Cold War mechanic, mapped to Latvia's real geopolitics.
+ *
+ * Three external actors run timed demands:
+ *  - 🇪🇺 Brussels — fiscal limits, rule-of-law, green, migration
+ *  - 🇷🇺 Moscow — pressure tools (gas, disinfo, border, cyber). Cannot be "satisfied" — only managed.
+ *  - 🇺🇸 Washington — defence & tech sovereignty
+ *
+ * Each demand surfaces as a timed card with a deadline. Ignoring has cost.
+ * Satisfying often hurts another power or a domestic faction.
+ *
+ * Pure-function module: state is held on GameState.superpowers.
+ */
+
+export type SuperpowerId = 'eu' | 'ru' | 'us';
+
+export interface SuperpowerDef {
+  id: SuperpowerId;
+  emoji: string;
+  name: string;
+  color: string;
+  /** A line summarising the relationship at "normal" levels. */
+  description: string;
+}
+
+export const SUPERPOWERS: SuperpowerDef[] = [
+  {
+    id: 'eu',
+    emoji: '🇪🇺',
+    name: 'Brussels',
+    color: '#003399',
+    description: 'EU Commission, Council, and the Parliament — friendly, exacting, occasionally exasperated.',
+  },
+  {
+    id: 'ru',
+    emoji: '🇷🇺',
+    name: 'Moscow',
+    color: '#8B0000',
+    description: 'Cannot be befriended. Can be managed. Probably wants something today.',
+  },
+  {
+    id: 'us',
+    emoji: '🇺🇸',
+    name: 'Washington',
+    color: '#4A90E2',
+    description: 'Allied. Distant. Interested when the F-35 fund line is on the table.',
+  },
+];
+
+export interface Demand {
+  id: string;
+  power: SuperpowerId;
+  title: string;
+  body: string;
+  /** Turn by which the demand should be resolved (or auto-fails). */
+  deadlineTurn: number;
+  options: DemandOption[];
+}
+
+export interface DemandOption {
+  label: string;
+  description: string;
+  /** Indicator deltas applied immediately. */
+  effects: { indicator: string; delta: number }[];
+  /** Faction reactions. */
+  factionReactions?: Record<string, 'love' | 'cheer' | 'meh' | 'frown' | 'rage'>;
+  /** Standing delta with each power. */
+  powerDeltas?: Partial<Record<SuperpowerId, number>>;
+}
+
+export interface SuperpowerState {
+  standing: Record<SuperpowerId, number>; // 0-100, lower = worse
+  active: Demand[];
+  resolved: { demandId: string; turn: number; chosen: number }[];
+}
+
+export function createInitialSuperpowers(): SuperpowerState {
+  return {
+    standing: { eu: 58, ru: 12, us: 60 },
+    active: [],
+    resolved: [],
+  };
+}
+
+// ─── Demand templates ────────────────────────────────────────────
+type DemandTemplate = Omit<Demand, 'id' | 'deadlineTurn'>;
+
+const EU_TEMPLATES: DemandTemplate[] = [
+  {
+    power: 'eu',
+    title: '🇪🇺 Brussels: Bring Deficit Under 3%',
+    body: 'The Commission notes your structural deficit has crept above the threshold. They would like a "clear glide path." They would prefer a fast one.',
+    options: [
+      {
+        label: 'Comply: austerity package',
+        description: 'Cut social spending, freeze hiring. Brussels nods. Citizens do not.',
+        effects: [
+          { indicator: 'publicDebt', delta: -4 },
+          { indicator: 'healthcareQuality', delta: -3 },
+          { indicator: 'socialStrain', delta: 4 },
+        ],
+        factionReactions: { reformBloc: 'cheer', socialDems: 'rage' },
+        powerDeltas: { eu: 8 },
+      },
+      {
+        label: 'Negotiate an extension',
+        description: 'A reasoned letter. A delegation. A 6-month grace period.',
+        effects: [{ indicator: 'euStanding', delta: -2 }],
+        factionReactions: { reformBloc: 'meh' },
+        powerDeltas: { eu: 2 },
+      },
+      {
+        label: 'Ignore — Brussels is bluffing',
+        description: 'It is not bluffing.',
+        effects: [{ indicator: 'foreignInvestment', delta: -6 }, { indicator: 'euStanding', delta: -6 }],
+        factionReactions: { reformBloc: 'rage', entrepreneurs: 'frown' },
+        powerDeltas: { eu: -12 },
+      },
+    ],
+  },
+  {
+    power: 'eu',
+    title: '🇪🇺 Brussels: Judicial Reform Directive',
+    body: 'The Commission has questions about KNAB independence and the appointment of judges. They expect answers.',
+    options: [
+      {
+        label: 'Pass the reform package',
+        description: 'KNAB gains real autonomy. Some prosecutors blink.',
+        effects: [{ indicator: 'corruptionLevel', delta: -6 }, { indicator: 'mediaTrust', delta: 4 }],
+        factionReactions: { reformBloc: 'love', entrepreneurs: 'frown' },
+        powerDeltas: { eu: 8 },
+      },
+      {
+        label: 'Symbolic gestures only',
+        description: 'A new committee. A new chair. Same prosecutors.',
+        effects: [{ indicator: 'corruptionLevel', delta: -1 }],
+        factionReactions: { reformBloc: 'frown' },
+        powerDeltas: { eu: -2 },
+      },
+    ],
+  },
+];
+
+const RU_TEMPLATES: DemandTemplate[] = [
+  {
+    power: 'ru',
+    title: '🇷🇺 Moscow: Gas Pricing Pressure',
+    body: 'A bilateral note arrives — couched in trade-policy language. The undertone is sharper. Latvia\'s transit volumes have been re-priced. Twice.',
+    options: [
+      {
+        label: 'Hold the line — diversify supplies',
+        description: 'Long-term Norwegian LNG contracts. Brussels approves. Wallet protests.',
+        effects: [
+          { indicator: 'energyIndependence', delta: 6 },
+          { indicator: 'publicDebt', delta: 2 },
+          { indicator: 'russiaRelations', delta: -3 },
+        ],
+        factionReactions: { natoBloc: 'love', green: 'cheer', entrepreneurs: 'meh' },
+        powerDeltas: { ru: -5, eu: 4 },
+      },
+      {
+        label: 'Limited transit deal',
+        description: 'Quiet workaround. The Russian invoice cools. So do the headlines.',
+        effects: [
+          { indicator: 'russiaRelations', delta: 3 },
+          { indicator: 'natoRelations', delta: -3 },
+          { indicator: 'energyIndependence', delta: -3 },
+        ],
+        factionReactions: { natoBloc: 'rage', identity: 'frown' },
+        powerDeltas: { ru: 6, us: -4, eu: -4 },
+      },
+    ],
+  },
+  {
+    power: 'ru',
+    title: '🇷🇺 Moscow: Disinformation Campaign',
+    body: 'A coordinated wave of social-media posts is targeting Latvian Russian-language audiences. The themes: language laws, alleged discrimination, NATO "occupation". The volume is significant.',
+    options: [
+      {
+        label: 'Strategic communications response',
+        description: 'A new MFA unit. Russian-language counter-narrative. KNAB monitors.',
+        effects: [
+          { indicator: 'mediaTrust', delta: 4 },
+          { indicator: 'russianMinorityIntegration', delta: 2 },
+          { indicator: 'cyberDefense', delta: 4 },
+        ],
+        factionReactions: { reformBloc: 'cheer', minority: 'cheer' },
+        powerDeltas: { ru: -3, eu: 3 },
+      },
+      {
+        label: 'Restrict access to suspect outlets',
+        description: 'Block the worst offenders. Press freedom rankings notice.',
+        effects: [
+          { indicator: 'mediaTrust', delta: -4 },
+          { indicator: 'cyberDefense', delta: 4 },
+          { indicator: 'russianMinorityIntegration', delta: -4 },
+        ],
+        factionReactions: { identity: 'cheer', reformBloc: 'frown', minority: 'rage' },
+        powerDeltas: { ru: -5, eu: -2 },
+      },
+    ],
+  },
+];
+
+const US_TEMPLATES: DemandTemplate[] = [
+  {
+    power: 'us',
+    title: '🇺🇸 Washington: HIMARS Procurement',
+    body: 'A US delegation arrives. They have brochures. The brochures are persuasive. Co-financing options are mentioned.',
+    options: [
+      {
+        label: 'Sign the deal — joint procurement',
+        description: 'A long invoice. A long delivery list. A long handshake.',
+        effects: [
+          { indicator: 'militaryReadiness', delta: 8 },
+          { indicator: 'publicDebt', delta: 3 },
+        ],
+        factionReactions: { natoBloc: 'love' },
+        powerDeltas: { us: 10, ru: -4 },
+      },
+      {
+        label: 'Wait for the European alternative',
+        description: 'Buy German next year. Buy French the year after.',
+        effects: [{ indicator: 'militaryReadiness', delta: 3 }],
+        factionReactions: { natoBloc: 'meh', reformBloc: 'cheer' },
+        powerDeltas: { us: -4, eu: 4 },
+      },
+    ],
+  },
+];
+
+// Reserved for the per-power lookup once we add an arbitrary-roller path.
+const _UNUSED_SUPERPOWERS_NS: Record<SuperpowerId, DemandTemplate[]> = {
+  eu: EU_TEMPLATES,
+  ru: RU_TEMPLATES,
+  us: US_TEMPLATES,
+};
+
+/**
+ * Roll for new demands each turn.
+ * - EU: ~once every 8 turns
+ * - RU: ~once every 6 turns (more often when relations are very low)
+ * - US: ~once every 12 turns
+ */
+export function rollSuperpowerDemands(
+  state: SuperpowerState,
+  currentTurn: number,
+  rng: Rng,
+  russiaRelations: number,
+): SuperpowerState {
+  const out: SuperpowerState = { ...state, active: [...state.active] };
+  const activePowers = new Set(out.active.map(d => d.power));
+
+  if (!activePowers.has('eu') && rng.next() < 1 / 8) {
+    const t = rng.pick(EU_TEMPLATES);
+    out.active.push({ ...t, id: `dem_eu_${currentTurn}`, deadlineTurn: currentTurn + 4 });
+  }
+  if (!activePowers.has('ru')) {
+    const russiaPressure = russiaRelations < 20 ? 1 / 4 : 1 / 7;
+    if (rng.next() < russiaPressure) {
+      const t = rng.pick(RU_TEMPLATES);
+      out.active.push({ ...t, id: `dem_ru_${currentTurn}`, deadlineTurn: currentTurn + 3 });
+    }
+  }
+  if (!activePowers.has('us') && rng.next() < 1 / 12) {
+    const t = rng.pick(US_TEMPLATES);
+    out.active.push({ ...t, id: `dem_us_${currentTurn}`, deadlineTurn: currentTurn + 5 });
+  }
+  return out;
+}
+
+/** Mark expired demands and apply the cost of inaction. */
+export function expireDemands(state: SuperpowerState, currentTurn: number): { state: SuperpowerState; penalties: Array<{ power: SuperpowerId; reason: string; standingDelta: number }> } {
+  const penalties: Array<{ power: SuperpowerId; reason: string; standingDelta: number }> = [];
+  const remaining: Demand[] = [];
+  const standing = { ...state.standing };
+  for (const d of state.active) {
+    if (d.deadlineTurn <= currentTurn) {
+      const drop = d.power === 'ru' ? 4 : 8;
+      standing[d.power] = Math.max(0, standing[d.power] - drop);
+      penalties.push({ power: d.power, reason: `Ignored: ${d.title}`, standingDelta: -drop });
+    } else {
+      remaining.push(d);
+    }
+  }
+  return { state: { ...state, active: remaining, standing }, penalties };
+}
+
+/** Resolve a chosen option for a demand. */
+export function resolveDemand(
+  state: SuperpowerState,
+  demandId: string,
+  optionIdx: number,
+  currentTurn: number,
+): { state: SuperpowerState; option: DemandOption | null } {
+  const d = state.active.find(x => x.id === demandId);
+  if (!d) return { state, option: null };
+  const opt = d.options[optionIdx];
+  if (!opt) return { state, option: null };
+  const standing = { ...state.standing };
+  if (opt.powerDeltas) {
+    for (const [pid, delta] of Object.entries(opt.powerDeltas) as [SuperpowerId, number][]) {
+      standing[pid] = Math.max(0, Math.min(100, standing[pid] + delta));
+    }
+  }
+  return {
+    state: {
+      ...state,
+      active: state.active.filter(x => x.id !== demandId),
+      standing,
+      resolved: [...state.resolved, { demandId, turn: currentTurn, chosen: optionIdx }],
+    },
+    option: opt,
+  };
+}
+
+export function getSuperpower(id: SuperpowerId): SuperpowerDef | undefined {
+  return SUPERPOWERS.find(s => s.id === id);
+}
+
+/** Returns ['Friendly', 'Cordial', 'Strained', 'Hostile'] */
+export function relationLabel(value: number): string {
+  if (value > 75) return 'Friendly';
+  if (value > 55) return 'Cordial';
+  if (value > 30) return 'Strained';
+  if (value > 15) return 'Hostile';
+  return 'Open Crisis';
+}

--- a/src/engine/traits.ts
+++ b/src/engine/traits.ts
@@ -1,0 +1,176 @@
+import type { Effect } from './types';
+
+/**
+ * El Presidente-style trait system. Pick 2 of 6 at game start.
+ *
+ * Traits do three things:
+ *  1. Multiply or shift the magnitude of effects matching their domain.
+ *  2. Shift starting indicator values (one-shot adjustments at game-start).
+ *  3. Bias faction starting approval (used once the faction layer ships in P2).
+ *
+ * The gameplay goal: two runs with different trait combos play visibly
+ * differently from quarter one.
+ */
+export type TraitId =
+  | 'technocrat'
+  | 'euroatlanticist'
+  | 'populist'
+  | 'crisisManager'
+  | 'natoHawk'
+  | 'balticPragmatist';
+
+export interface TraitDef {
+  id: TraitId;
+  emoji: string;
+  name: string;
+  tagline: string;
+  description: string;
+  /** One-shot indicator deltas applied at game start. */
+  startBias: Partial<Record<string, number>>;
+  /** Faction starting offsets (factionId -> delta). Used in P2. */
+  factionBias?: Record<string, number>;
+  /** Per-effect multiplier function — applied in applyEffect. */
+  modifyEffect?: (effect: Effect) => Effect;
+  /** Domains this trait specialises in (cosmetic / tooltip use). */
+  domains: string[];
+}
+
+const ECONOMY_INDICATORS = new Set([
+  'gdp', 'gdpGrowth', 'foreignInvestment', 'taxBurden', 'publicDebt',
+  'unemployment', 'inflation', 'portActivity', 'techSector',
+]);
+const SECURITY_INDICATORS = new Set([
+  'militaryReadiness', 'natoRelations', 'borderSecurity', 'cyberDefense',
+]);
+const SOCIAL_INDICATORS = new Set([
+  'publicHappiness', 'publicConfidence', 'socialStrain',
+  'healthcareQuality', 'educationQuality', 'socialCohesion',
+]);
+
+export const TRAIT_DEFS: TraitDef[] = [
+  {
+    id: 'technocrat',
+    emoji: '📊',
+    name: 'Technocrat',
+    tagline: '"Spreadsheets don\'t lie. People do."',
+    description:
+      'Economic and digital indicators move 20% harder under your watch. Factions remain politely indifferent — nobody loves a slide deck.',
+    startBias: { foreignInvestment: 4, taxBurden: -2, mediaTrust: -2 },
+    domains: ['economy', 'digital'],
+    modifyEffect: (e) => {
+      if (ECONOMY_INDICATORS.has(e.indicator) || e.indicator === 'digitalInfra') {
+        return { ...e, delta: e.delta * 1.2 };
+      }
+      return e;
+    },
+  },
+  {
+    id: 'euroatlanticist',
+    emoji: '🇪🇺',
+    name: 'Euro-Atlanticist',
+    tagline: '"Brussels has called. We pick up."',
+    description:
+      'Start with strong EU and NATO standing. National Identity bloc is cool toward you — and Russia notices.',
+    startBias: { euStanding: 12, natoRelations: 10, nationalIdentity: -6, russiaRelations: -3 },
+    domains: ['foreign', 'EU'],
+    modifyEffect: (e) => {
+      if (['euStanding', 'natoRelations'].includes(e.indicator) && e.delta > 0) {
+        return { ...e, delta: e.delta * 1.25 };
+      }
+      return e;
+    },
+  },
+  {
+    id: 'populist',
+    emoji: '🎤',
+    name: 'Populist',
+    tagline: '"The people know what they want. Usually it\'s lower taxes."',
+    description:
+      'Public Confidence recovers quickly after setbacks. The fiscal hangover, however, also accumulates faster.',
+    startBias: { publicConfidence: 8, publicDebt: 4, foreignInvestment: -3 },
+    domains: ['social', 'media'],
+    modifyEffect: (e) => {
+      if (e.indicator === 'publicConfidence' && e.delta > 0) return { ...e, delta: e.delta * 1.4 };
+      if (e.indicator === 'publicDebt' && e.delta > 0) return { ...e, delta: e.delta * 1.2 };
+      return e;
+    },
+  },
+  {
+    id: 'crisisManager',
+    emoji: '🧯',
+    name: 'Crisis Manager',
+    tagline: '"I do my best work when everything\'s on fire."',
+    description:
+      'Crisis-category events resolve more favourably. In quiet quarters, you fidget — calm policy moves slightly less effectively.',
+    startBias: { socialStrain: -4 },
+    domains: ['crisis'],
+    // Effect scoping is per-effect, not per-event; the bonus applies indirectly via reduced
+    // strain on bad-news effects.
+    modifyEffect: (e) => {
+      if (SOCIAL_INDICATORS.has(e.indicator) && e.delta < 0) {
+        return { ...e, delta: e.delta * 0.8 };
+      }
+      return e;
+    },
+  },
+  {
+    id: 'natoHawk',
+    emoji: '🦅',
+    name: 'NATO Hawk',
+    tagline: '"Two-point-five percent is the floor, not the ceiling."',
+    description:
+      'Security and military investments overperform. Domestic social spending faces tougher coalition resistance.',
+    startBias: { militaryReadiness: 8, natoRelations: 6, socialCohesion: -3, healthcareQuality: -2 },
+    domains: ['security', 'defense'],
+    modifyEffect: (e) => {
+      if (SECURITY_INDICATORS.has(e.indicator)) return { ...e, delta: e.delta * 1.25 };
+      if (e.indicator === 'healthcareQuality' && e.delta > 0) return { ...e, delta: e.delta * 0.85 };
+      return e;
+    },
+  },
+  {
+    id: 'balticPragmatist',
+    emoji: '🤝',
+    name: 'Baltic Pragmatist',
+    tagline: '"No one loves us. No one hates us. It\'s working."',
+    description:
+      'Every faction starts neutral and stable. The price: nobody adores you, and "passionate ally" events stay locked.',
+    startBias: {},
+    domains: ['balance'],
+    modifyEffect: (e) => ({ ...e, delta: e.delta * 0.9 }),
+  },
+];
+
+export function getTrait(id: TraitId): TraitDef | undefined {
+  return TRAIT_DEFS.find(t => t.id === id);
+}
+
+/** Apply all trait-startBias deltas to an indicator map. */
+export function applyTraitStartBias(
+  indicators: Record<string, number>,
+  traitIds: TraitId[],
+): Record<string, number> {
+  const next = { ...indicators };
+  for (const tid of traitIds) {
+    const t = getTrait(tid);
+    if (!t) continue;
+    for (const [key, delta] of Object.entries(t.startBias)) {
+      if (typeof delta !== 'number') continue;
+      next[key] = (next[key] ?? 0) + delta;
+    }
+  }
+  return next;
+}
+
+/** Compose trait effect modifiers — applied in applyEffect before delta variation. */
+export function applyTraitEffectModifiers(
+  effect: Effect,
+  traitIds: TraitId[],
+): Effect {
+  let result = effect;
+  for (const tid of traitIds) {
+    const t = getTrait(tid);
+    if (t?.modifyEffect) result = t.modifyEffect(result);
+  }
+  return result;
+}

--- a/src/engine/turn.ts
+++ b/src/engine/turn.ts
@@ -5,6 +5,8 @@ import { createRng } from './random';
 import { updatePartyApprovals, updateCoalitionLoyalty, runElection, calculateRatings, getCoalitionSeats, getCoalitionLoyalty, checkCoalitionStability } from './politics';
 import { scheduleEcho, dueEchoes } from './echoes';
 import { generateHeadlines } from './newsfeed';
+import { applyFactionReactions, driftFactionApproval } from './factions';
+import { evaluatePromises } from './manifesto';
 
 export interface TurnResult {
   state: GameState;
@@ -53,12 +55,16 @@ export function resolveTurn(
 
   let newState: GameState = { ...state, coalitionCrises: undefined };
 
-  // 1. Apply all choice effects + schedule echoes for flagged choices
+  // 1. Apply all choice effects + schedule echoes + faction reactions
   const newEchoes = [];
+  let factionApproval = { ...(newState.factionApproval ?? {}) };
   for (const { event, choiceIndex } of decisions) {
     const choice = event.choices[choiceIndex];
     for (const effect of choice.effects) {
       newState = applyEffect(newState, effect, `${event.id}:${choice.label}`, rng);
+    }
+    if (choice.factionReactions) {
+      factionApproval = applyFactionReactions(factionApproval as never, choice.factionReactions, rng) as never;
     }
     if (choice.hasEcho) {
       const echo = scheduleEcho(event, choice, newState.turn, newState.year, newState.quarter, rng);
@@ -75,6 +81,7 @@ export function resolveTurn(
   newState = {
     ...newState,
     pendingEchoes: [...(newState.pendingEchoes ?? []), ...newEchoes],
+    factionApproval,
   };
 
   // 2. Process scheduled effects from previous turns
@@ -82,6 +89,12 @@ export function resolveTurn(
 
   // 3. Apply cascading second-order effects
   newState = applyCascadingEffects(newState, rng);
+
+  // 3a. Passive faction drift based on indicator priorities + cynicism
+  newState = {
+    ...newState,
+    factionApproval: driftFactionApproval(newState.factionApproval as never, newState.indicators, rng, newState.cynicism ?? 0) as never,
+  };
 
   // 3b. Fire any echoes due this turn
   const { fired, remaining } = dueEchoes(newState.pendingEchoes ?? [], newState.turn);
@@ -147,6 +160,11 @@ export function resolveTurn(
     newState.parliament = newParl;
     newState.electionPending = true;
     newState.lastElectionResult = result;
+    // Evaluate manifesto promises for the just-ended term
+    const currentTermIndex = newParl.electionHistory.length - 1;
+    const { cynicismDelta, resolved } = evaluatePromises(newState.promises ?? [], newState, currentTermIndex);
+    newState.promises = resolved;
+    newState.cynicism = Math.max(0, (newState.cynicism ?? 0) + cynicismDelta);
     if (!result.won) {
       newState.gameOver = true;
       newState.gameOverReason = `Election defeat! Your coalition won only ${getCoalitionSeats(newParl)} seats — not enough to govern. The opposition forms a new government. Your time as leader is over.`;

--- a/src/engine/turn.ts
+++ b/src/engine/turn.ts
@@ -7,6 +7,11 @@ import { scheduleEcho, dueEchoes } from './echoes';
 import { generateHeadlines } from './newsfeed';
 import { applyFactionReactions, driftFactionApproval } from './factions';
 import { evaluatePromises } from './manifesto';
+import { checkArcTriggers, nextArcEvent, ARCS } from './arcs';
+import { rollSuperpowerDemands, expireDemands } from './superpowers';
+import { applyDecreeEffects } from './decrees';
+import { INDICATORS } from './indicators';
+import { clamp } from './random';
 
 export interface TurnResult {
   state: GameState;
@@ -29,7 +34,7 @@ export function getCampaignSeason(state: GameState): number {
 /** Start a new turn: select events to present to the player */
 export function startTurn(state: GameState, allEvents: GameEvent[]): TurnResult {
   const rng = createRng(state.seed + state.turn * 7919);
-  
+
   // Inject virtual indicators for event preconditions
   const campaign = getCampaignSeason(state);
   const loyalty = getCoalitionLoyalty(state.parliament);
@@ -40,9 +45,24 @@ export function startTurn(state: GameState, allEvents: GameEvent[]): TurnResult 
     coalitionStability,
   };
   const stateWithVirtuals = { ...state, indicators: virtualIndicators };
-  
-  const events = selectEvents(stateWithVirtuals, allEvents, rng, 2);
-  return { state, events };
+
+  // 1. Trigger any newly-eligible arcs (read-only — no state mutation)
+  const completed = state.completedArcs ?? new Set();
+  const activeArcs = checkArcTriggers(state.activeArcs ?? [], completed, state, state.turn);
+
+  // 2. Pull arc-stage events that are due for any active arc
+  const arcEvents: GameEvent[] = [];
+  for (const a of activeArcs) {
+    const { event } = nextArcEvent(a, state.turn, state);
+    if (event) arcEvents.push(event);
+  }
+
+  // 3. Static event pool — pull at most (2 - arc count) so we don't flood
+  const remainingSlots = Math.max(1, 2 - arcEvents.length);
+  const events = selectEvents(stateWithVirtuals, allEvents, rng, remainingSlots);
+
+  // Persist new arc triggers; stage advances happen in resolveTurn.
+  return { state: { ...state, activeArcs }, events: [...arcEvents, ...events] };
 }
 
 /** Resolve a turn after player has made choices */
@@ -84,11 +104,42 @@ export function resolveTurn(
     factionApproval,
   };
 
+  // 1b. Advance any arc stages that were resolved this turn (by id pattern)
+  const completedArcs = new Set(newState.completedArcs ?? []);
+  const activeArcs = (newState.activeArcs ?? []).map(a => {
+    const arcDef = ARCS.find(x => x.id === a.arcId);
+    if (!arcDef) return a;
+    const matched = decisions.find(d => d.event.id.startsWith(`arc_${a.arcId}_`));
+    if (matched) {
+      const newStage = a.stage + 1;
+      if (newStage >= arcDef.stages.length) {
+        completedArcs.add(a.arcId);
+      }
+      return { ...a, stage: newStage };
+    }
+    return a;
+  }).filter(a => !completedArcs.has(a.arcId));
+  newState = { ...newState, activeArcs, completedArcs };
+
   // 2. Process scheduled effects from previous turns
   newState = processScheduledEffects(newState, rng);
 
   // 3. Apply cascading second-order effects
   newState = applyCascadingEffects(newState, rng);
+
+  // 3a. Apply per-quarter decree effects + clamp
+  if (newState.decrees && newState.decrees.active.length > 0) {
+    const after = applyDecreeEffects(newState.decrees, newState.indicators);
+    // Clamp to indicator metadata bounds
+    const clamped: Record<string, number> = {};
+    for (const k of Object.keys(after)) {
+      const meta = INDICATORS.find(i => i.key === k);
+      const min = meta?.min ?? 0;
+      const max = meta?.max ?? 100;
+      clamped[k] = clamp(after[k], min, max);
+    }
+    newState = { ...newState, indicators: clamped };
+  }
 
   // 3a. Passive faction drift based on indicator priorities + cynicism
   newState = {
@@ -173,6 +224,20 @@ export function resolveTurn(
 
   // 9. Update international ratings
   newState.ratings = calculateRatings(newState.indicators);
+
+  // 9b. Accrue Political Capital each quarter (bonus from reform position).
+  const civilBonus = (newState.constitution?.positions.civil ?? 0) > 0 ? 1 : 0;
+  newState.constitution = newState.constitution
+    ? { ...newState.constitution, politicalCapital: Math.min(40, newState.constitution.politicalCapital + 1 + civilBonus) }
+    : newState.constitution;
+
+  // 9c. Roll & expire superpower demands
+  const spRng = createRng(state.seed + newState.turn * 24317);
+  let spState = newState.superpowers ?? { standing: { eu: 50, ru: 12, us: 50 }, active: [], resolved: [] };
+  const { state: expiredState } = expireDemands(spState, newState.turn);
+  spState = expiredState;
+  spState = rollSuperpowerDemands(spState, newState.turn, spRng, newState.indicators.russiaRelations);
+  newState.superpowers = spState;
 
   // 10. Check game over
   newState = checkGameOver(newState);

--- a/src/engine/turn.ts
+++ b/src/engine/turn.ts
@@ -3,6 +3,8 @@ import { applyEffect, processScheduledEffects, applyCascadingEffects, checkGameO
 import { selectEvents, generateNarrative } from './events';
 import { createRng } from './random';
 import { updatePartyApprovals, updateCoalitionLoyalty, runElection, calculateRatings, getCoalitionSeats, getCoalitionLoyalty, checkCoalitionStability } from './politics';
+import { scheduleEcho, dueEchoes } from './echoes';
+import { generateHeadlines } from './newsfeed';
 
 export interface TurnResult {
   state: GameState;
@@ -51,11 +53,16 @@ export function resolveTurn(
 
   let newState: GameState = { ...state, coalitionCrises: undefined };
 
-  // 1. Apply all choice effects
+  // 1. Apply all choice effects + schedule echoes for flagged choices
+  const newEchoes = [];
   for (const { event, choiceIndex } of decisions) {
     const choice = event.choices[choiceIndex];
     for (const effect of choice.effects) {
       newState = applyEffect(newState, effect, `${event.id}:${choice.label}`, rng);
+    }
+    if (choice.hasEcho) {
+      const echo = scheduleEcho(event, choice, newState.turn, newState.year, newState.quarter, rng);
+      if (echo) newEchoes.push(echo);
     }
     // Mark one-time events
     if (event.oneTime) {
@@ -65,6 +72,10 @@ export function resolveTurn(
       };
     }
   }
+  newState = {
+    ...newState,
+    pendingEchoes: [...(newState.pendingEchoes ?? []), ...newEchoes],
+  };
 
   // 2. Process scheduled effects from previous turns
   newState = processScheduledEffects(newState, rng);
@@ -72,8 +83,13 @@ export function resolveTurn(
   // 3. Apply cascading second-order effects
   newState = applyCascadingEffects(newState, rng);
 
-  // 4. Generate narrative
+  // 3b. Fire any echoes due this turn
+  const { fired, remaining } = dueEchoes(newState.pendingEchoes ?? [], newState.turn);
+  newState = { ...newState, pendingEchoes: remaining };
+
+  // 4. Generate narrative + headlines
   const narrative = generateNarrative(newState, decisions);
+  const headlines = generateHeadlines(newState, decisions, indicatorsBefore, rng);
 
   // 5. Record history
   const record: TurnRecord = {
@@ -84,6 +100,8 @@ export function resolveTurn(
     indicatorsBefore,
     indicatorsAfter: { ...newState.indicators },
     narrative,
+    echoes: fired.map(e => e.narrative),
+    headlines,
   };
 
   // 6. Advance time

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,5 +1,7 @@
 import type { Parliament, InternationalRatings, ElectionResult, CoalitionCrisis } from './politics';
 import type { TraitId } from './traits';
+import type { FactionId, ReactionLevel } from './factions';
+import type { PromiseRecord } from './manifesto';
 
 // ─── Core Game Types ─────────────────────────────────────────────
 export interface GameState {
@@ -23,6 +25,12 @@ export interface GameState {
   traits: TraitId[];
   /** Pending narrative echoes that fire on a later turn. */
   pendingEchoes: Echo[];
+  /** Faction approval map — Tropico-style ideological blocs. */
+  factionApproval: Record<FactionId, number>;
+  /** Manifesto promises made (with kept/broken status once evaluated). */
+  promises: PromiseRecord[];
+  /** Permanent voter-cynicism meter — accumulates with broken promises. */
+  cynicism: number;
 }
 
 export interface ScheduledEffect {
@@ -63,6 +71,11 @@ export interface Choice {
    * one from the event title + dominant effect.
    */
   echoTemplate?: string;
+  /**
+   * Tropico-style faction reactions to this choice. Each entry shifts faction
+   * approval by the level's delta. Missing factions are unaffected.
+   */
+  factionReactions?: Partial<Record<FactionId, ReactionLevel>>;
 }
 
 export type EventCategory = 'economy' | 'security' | 'society' | 'diplomacy' | 'science' | 'crisis' | 'environment' | 'culture' | 'petition';
@@ -77,6 +90,8 @@ export interface GameEvent {
   weight: number;
   oneTime: boolean;
   flavor?: string;
+  /** Trigger the Advisor Debate panel before showing choices. */
+  highStakes?: boolean;
 }
 
 export interface TurnRecord {

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -2,6 +2,10 @@ import type { Parliament, InternationalRatings, ElectionResult, CoalitionCrisis 
 import type { TraitId } from './traits';
 import type { FactionId, ReactionLevel } from './factions';
 import type { PromiseRecord } from './manifesto';
+import type { ConstitutionState } from './constitution';
+import type { ActiveArc, ArcId } from './arcs';
+import type { SuperpowerState } from './superpowers';
+import type { DecreeState } from './decrees';
 
 // ─── Core Game Types ─────────────────────────────────────────────
 export interface GameState {
@@ -31,6 +35,16 @@ export interface GameState {
   promises: PromiseRecord[];
   /** Permanent voter-cynicism meter — accumulates with broken promises. */
   cynicism: number;
+  /** Frostpunk-style Book of Laws — 4 pillars + Political Capital. */
+  constitution: ConstitutionState;
+  /** Currently-running multi-quarter event arcs (CK3-style storylines). */
+  activeArcs: ActiveArc[];
+  /** Arcs the player has fully completed (won't re-trigger). */
+  completedArcs: Set<ArcId>;
+  /** Tropico-style superpower demand queue (EU/RU/US). */
+  superpowers: SuperpowerState;
+  /** Active toggleable policy decrees (Tropico edicts). */
+  decrees: DecreeState;
 }
 
 export interface ScheduledEffect {
@@ -76,6 +90,12 @@ export interface Choice {
    * approval by the level's delta. Missing factions are unaffected.
    */
   factionReactions?: Partial<Record<FactionId, ReactionLevel>>;
+  /**
+   * Reigns/Frostpunk-style irreversibility flag. The UI shows a broken-chain
+   * badge and a confirmation modal before applying the choice. Choosing here
+   * is final — and rendered visibly so.
+   */
+  irreversible?: boolean;
 }
 
 export type EventCategory = 'economy' | 'security' | 'society' | 'diplomacy' | 'science' | 'crisis' | 'environment' | 'culture' | 'petition';

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,4 +1,5 @@
 import type { Parliament, InternationalRatings, ElectionResult, CoalitionCrisis } from './politics';
+import type { TraitId } from './traits';
 
 // ─── Core Game Types ─────────────────────────────────────────────
 export interface GameState {
@@ -18,6 +19,10 @@ export interface GameState {
   electionPending?: boolean;
   lastElectionResult?: ElectionResult;
   coalitionCrises?: CoalitionCrisis[];
+  /** Player-picked traits (max 2). */
+  traits: TraitId[];
+  /** Pending narrative echoes that fire on a later turn. */
+  pendingEchoes: Echo[];
 }
 
 export interface ScheduledEffect {
@@ -48,6 +53,16 @@ export interface Choice {
   description: string;
   effects: Effect[];
   humor?: string;
+  /**
+   * When true, the engine schedules a narrative "Echo" that surfaces 2-4 turns
+   * after this choice. The Echo references the original decision by date.
+   */
+  hasEcho?: boolean;
+  /**
+   * Optional custom echo narrative template. If omitted, the engine generates
+   * one from the event title + dominant effect.
+   */
+  echoTemplate?: string;
 }
 
 export type EventCategory = 'economy' | 'security' | 'society' | 'diplomacy' | 'science' | 'crisis' | 'environment' | 'culture' | 'petition';
@@ -71,6 +86,18 @@ export interface TurnRecord {
   events: { event: GameEvent; choiceIndex: number }[];
   indicatorsBefore: Record<string, number>;
   indicatorsAfter: Record<string, number>;
+  narrative: string;
+  /** Echo narratives that fired this turn (delayed consequences from prior turns). */
+  echoes?: string[];
+  /** Procedurally-generated news headlines for this quarter (Tropico-style). */
+  headlines?: string[];
+}
+
+export interface Echo {
+  id: string;
+  sourceEventTitle: string;
+  sourceQuarterLabel: string; // "Q2 2025"
+  fireTurn: number;
   narrative: string;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -106,6 +106,23 @@ h1, h2, h3, h4 {
   50% { box-shadow: 0 0 0 8px rgba(184, 134, 11, 0); }
 }
 
+/* Crisis shake — used by FactionPulse when a faction is in crisis */
+.faction-shake { animation: factionShake 1.4s ease-in-out infinite; }
+@keyframes factionShake {
+  0%, 100% { transform: translateX(0); }
+  20% { transform: translateX(-1.5px) rotate(-2deg); }
+  40% { transform: translateX(1.5px) rotate(2deg); }
+  60% { transform: translateX(-1.5px); }
+  80% { transform: translateX(1px); }
+}
+
+/* Love glow — used by FactionPulse when a faction adores you */
+.faction-glow { animation: factionGlow 3s ease-in-out infinite; }
+@keyframes factionGlow {
+  0%, 100% { box-shadow: 0 0 0 2px #16A34A, 0 0 8px rgba(22,163,74,0.4); }
+  50% { box-shadow: 0 0 0 2px #16A34A, 0 0 14px rgba(22,163,74,0.7); }
+}
+
 /* ── Utilities ────────────────────────────────── */
 * { -webkit-tap-highlight-color: transparent; }
 ::selection { background: rgba(158, 48, 57, 0.15); }

--- a/src/ui/AdvisorDebate.tsx
+++ b/src/ui/AdvisorDebate.tsx
@@ -1,0 +1,72 @@
+import { useMemo, useState } from 'react';
+import type { GameEvent } from '../engine/types';
+import { FACTIONS } from '../engine/factions';
+import { pickDebatePanel, ministerLineFor } from '../engine/ministers';
+import { createRng } from '../engine/random';
+
+interface Props {
+  event: GameEvent;
+  /** Seed for deterministic line selection — pass turn number. */
+  seed: number;
+}
+
+export default function AdvisorDebate({ event, seed }: Props) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  const debate = useMemo(() => {
+    const rng = createRng(seed + event.id.length * 31);
+    const ministers = pickDebatePanel(event, rng);
+    return ministers.map(m => ({
+      minister: m,
+      line: ministerLineFor(m, event, rng),
+      faction: FACTIONS.find(f => f.id === m.factionId),
+    }));
+  }, [event, seed]);
+
+  return (
+    <div className="rounded-xl p-3 mb-3" style={{ background: 'rgba(184,134,11,0.06)', border: '1px solid rgba(184,134,11,0.2)' }}>
+      <div className="flex items-center justify-between mb-2">
+        <h4 className="text-[10px] font-bold uppercase tracking-[0.2em]" style={{ color: '#B8860B' }}>
+          ⚡ Cabinet Briefing — High Stakes
+        </h4>
+        <button
+          onClick={() => setCollapsed(c => !c)}
+          className="text-[10px]"
+          style={{ color: '#78716C' }}
+        >
+          {collapsed ? '▼ Show' : '▲ Hide'}
+        </button>
+      </div>
+      {!collapsed && (
+        <div className="space-y-2">
+          {debate.map(({ minister, line, faction }, i) => (
+            <div key={minister.id} className="flex items-start gap-2 fade-in" style={{ animationDelay: `${i * 0.1}s` }}>
+              <div
+                className="w-8 h-8 rounded-full flex items-center justify-center text-[10px] font-bold shrink-0"
+                style={{ background: faction?.color ?? '#78716C', color: '#FFFFFF' }}
+              >
+                {minister.initials}
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-baseline gap-2 flex-wrap">
+                  <span className="text-xs font-semibold" style={{ color: '#1C1917' }}>{minister.name}</span>
+                  <span className="text-[10px]" style={{ color: '#78716C' }}>{minister.title}</span>
+                  <span
+                    className="text-[9px] px-1.5 py-0.5 rounded-full"
+                    style={{ background: 'rgba(28,25,23,0.05)', color: '#78716C' }}
+                  >
+                    {minister.biasLabel}
+                  </span>
+                </div>
+                <p className="text-xs leading-relaxed mt-0.5" style={{ color: '#3D3731' }}>{line}</p>
+              </div>
+            </div>
+          ))}
+          <p className="text-[10px] italic pt-1.5 mt-2" style={{ color: '#A8A29E', borderTop: '1px dashed rgba(28,25,23,0.08)' }}>
+            Ministers have biases. Read them like you would a newspaper editorial — with one eyebrow raised.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/ConstitutionPanel.tsx
+++ b/src/ui/ConstitutionPanel.tsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import type { GameState } from '../engine/types';
+import { PILLARS, canAdvancePillar, type PillarId } from '../engine/constitution';
+
+interface Props {
+  state: GameState;
+  onAdvance: (pillar: PillarId, direction: 1 | -1) => void;
+}
+
+const POSITION_LABEL = ['Hard Left', 'Left-leaning', 'Centre', 'Right-leaning', 'Hard Right'];
+
+export default function ConstitutionPanel({ state, onAdvance }: Props) {
+  const [openPillar, setOpenPillar] = useState<PillarId | null>(null);
+  const c = state.constitution;
+
+  return (
+    <div className="glass-card p-3 mb-3">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#9E3039' }}>
+          📜 The Constitution
+        </h3>
+        <span className="text-[10px] font-data px-2 py-0.5 rounded-full" style={{ background: 'rgba(184,134,11,0.12)', color: '#B8860B' }} title="Political Capital">
+          PC: {c.politicalCapital}
+        </span>
+      </div>
+      <div className="space-y-2">
+        {PILLARS.map(p => {
+          const pos = c.positions[p.id];
+          const idx = pos + 2; // 0..4
+          const isOpen = openPillar === p.id;
+          return (
+            <div key={p.id}>
+              <button
+                onClick={() => setOpenPillar(isOpen ? null : p.id)}
+                className="w-full flex items-center gap-2 text-left text-xs py-1"
+              >
+                <span>{p.emoji}</span>
+                <span className="font-semibold" style={{ color: '#1C1917' }}>{p.name}</span>
+                <span className="ml-auto" style={{ color: '#78716C' }}>{POSITION_LABEL[idx]}</span>
+                <span className="text-[10px]" style={{ color: '#A8A29E' }}>{isOpen ? '▲' : '▼'}</span>
+              </button>
+              <div className="relative h-1.5 mx-1 rounded-full" style={{ background: 'rgba(28,25,23,0.08)' }}>
+                <div
+                  className="absolute top-1/2 w-3 h-3 rounded-full -translate-y-1/2 transition-all"
+                  style={{ left: `calc(${(idx / 4) * 100}% - 6px)`, background: '#B8860B' }}
+                />
+              </div>
+              <div className="flex justify-between text-[9px] mt-0.5 px-1" style={{ color: '#A8A29E' }}>
+                <span>{p.axisLeft}</span>
+                <span>{p.axisRight}</span>
+              </div>
+              {isOpen && (() => {
+                const leftCheck = canAdvancePillar(c, p.id, -1);
+                const rightCheck = canAdvancePillar(c, p.id, 1);
+                const leftStep = p.steps[pos - 1];
+                const rightStep = p.steps[pos + 1];
+                return (
+                  <div className="mt-2 pt-2 grid grid-cols-2 gap-2 fade-in" style={{ borderTop: '1px dashed rgba(28,25,23,0.08)' }}>
+                    <button
+                      onClick={() => leftCheck.ok && onAdvance(p.id, -1)}
+                      disabled={!leftCheck.ok}
+                      className="text-left p-2 rounded-lg transition-all"
+                      style={{
+                        background: leftCheck.ok ? 'rgba(184,134,11,0.05)' : 'rgba(28,25,23,0.03)',
+                        cursor: leftCheck.ok ? 'pointer' : 'not-allowed',
+                        opacity: leftCheck.ok ? 1 : 0.45,
+                      }}
+                      title={leftCheck.reason}
+                    >
+                      <div className="text-[10px] font-bold" style={{ color: '#9E3039' }}>← Move Left</div>
+                      <div className="text-[10px] font-semibold" style={{ color: '#1C1917' }}>{leftStep?.label ?? '—'}</div>
+                      <div className="text-[9px]" style={{ color: '#78716C' }}>{leftStep?.description ?? leftCheck.reason}</div>
+                      {leftStep && <div className="text-[9px] font-data mt-0.5" style={{ color: '#B8860B' }}>−{leftStep.cost} PC</div>}
+                    </button>
+                    <button
+                      onClick={() => rightCheck.ok && onAdvance(p.id, 1)}
+                      disabled={!rightCheck.ok}
+                      className="text-right p-2 rounded-lg transition-all"
+                      style={{
+                        background: rightCheck.ok ? 'rgba(184,134,11,0.05)' : 'rgba(28,25,23,0.03)',
+                        cursor: rightCheck.ok ? 'pointer' : 'not-allowed',
+                        opacity: rightCheck.ok ? 1 : 0.45,
+                      }}
+                      title={rightCheck.reason}
+                    >
+                      <div className="text-[10px] font-bold" style={{ color: '#9E3039' }}>Move Right →</div>
+                      <div className="text-[10px] font-semibold" style={{ color: '#1C1917' }}>{rightStep?.label ?? '—'}</div>
+                      <div className="text-[9px]" style={{ color: '#78716C' }}>{rightStep?.description ?? rightCheck.reason}</div>
+                      {rightStep && <div className="text-[9px] font-data mt-0.5" style={{ color: '#B8860B' }}>−{rightStep.cost} PC</div>}
+                    </button>
+                  </div>
+                );
+              })()}
+            </div>
+          );
+        })}
+      </div>
+      <p className="text-[10px] mt-2 pt-2" style={{ color: '#A8A29E', borderTop: '1px solid rgba(28,25,23,0.06)' }}>
+        Once you amend a pillar, you cannot reverse it. Choose your republic carefully.
+      </p>
+    </div>
+  );
+}

--- a/src/ui/DecreesPanel.tsx
+++ b/src/ui/DecreesPanel.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import type { GameState } from '../engine/types';
+import { DECREES, canEnact } from '../engine/decrees';
+
+interface Props {
+  state: GameState;
+  onEnact: (decreeId: string) => void;
+  onRevoke: (decreeId: string) => void;
+}
+
+export default function DecreesPanel({ state, onEnact, onRevoke }: Props) {
+  const [showAll, setShowAll] = useState(false);
+  const active = new Set(state.decrees.active);
+  const pc = state.constitution.politicalCapital;
+
+  return (
+    <div className="glass-card p-3 mb-3">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#9E3039' }}>
+          📜 Standing Decrees
+        </h3>
+        <span className="text-[10px] font-data px-2 py-0.5 rounded-full" style={{ background: 'rgba(184,134,11,0.12)', color: '#B8860B' }}>
+          {state.decrees.active.length} active
+        </span>
+      </div>
+
+      {/* Active decrees */}
+      {state.decrees.active.length > 0 && (
+        <div className="space-y-1.5 mb-2">
+          {state.decrees.active.map(did => {
+            const d = DECREES.find(x => x.id === did);
+            if (!d) return null;
+            const canRevoke = pc >= d.revokeCost;
+            return (
+              <div key={did} className="flex items-center justify-between p-2 rounded-lg" style={{ background: 'rgba(184,134,11,0.06)' }}>
+                <div className="flex items-center gap-2 min-w-0">
+                  <span className="text-base">{d.emoji}</span>
+                  <div className="min-w-0">
+                    <div className="text-[11px] font-semibold truncate" style={{ color: '#1C1917' }}>{d.name}</div>
+                    <div className="text-[9px]" style={{ color: '#78716C' }}>active</div>
+                  </div>
+                </div>
+                <button
+                  onClick={() => canRevoke && onRevoke(did)}
+                  disabled={!canRevoke}
+                  className="text-[10px] px-2 py-0.5 rounded font-medium"
+                  style={{
+                    background: canRevoke ? '#9E3039' : 'rgba(28,25,23,0.05)',
+                    color: canRevoke ? '#FFFFFF' : '#78716C',
+                    cursor: canRevoke ? 'pointer' : 'not-allowed',
+                  }}
+                  title={canRevoke ? '' : `Needs ${d.revokeCost} PC`}
+                >
+                  Revoke −{d.revokeCost}PC
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Toggle to show available */}
+      <button
+        onClick={() => setShowAll(s => !s)}
+        className="text-[11px] w-full text-left py-1"
+        style={{ color: '#9E3039' }}
+      >
+        {showAll ? '▲ Hide library' : '▼ Show decree library'}
+      </button>
+
+      {showAll && (
+        <div className="space-y-1.5 mt-1 fade-in">
+          {DECREES.filter(d => !active.has(d.id)).map(d => {
+            const check = canEnact(state.decrees, d.id, pc);
+            return (
+              <button
+                key={d.id}
+                onClick={() => check.ok && onEnact(d.id)}
+                disabled={!check.ok}
+                className="w-full text-left p-2 rounded-lg transition-all"
+                style={{
+                  background: check.ok ? 'rgba(255,255,255,0.6)' : 'rgba(28,25,23,0.03)',
+                  border: '1px solid rgba(28,25,23,0.06)',
+                  opacity: check.ok ? 1 : 0.55,
+                  cursor: check.ok ? 'pointer' : 'not-allowed',
+                }}
+                title={check.reason ?? ''}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className="text-base">{d.emoji}</span>
+                    <div className="min-w-0">
+                      <div className="text-[11px] font-semibold truncate" style={{ color: '#1C1917' }}>{d.name}</div>
+                      <div className="text-[10px] line-clamp-2" style={{ color: '#78716C' }}>{d.description}</div>
+                    </div>
+                  </div>
+                  <span className="text-[10px] font-data shrink-0 px-2 py-0.5 rounded" style={{ background: 'rgba(184,134,11,0.12)', color: '#B8860B' }}>
+                    {d.enactCost} PC
+                  </span>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/ui/EventCard.tsx
+++ b/src/ui/EventCard.tsx
@@ -2,15 +2,20 @@ import { useState } from 'react';
 import { GameEvent } from '../engine/types';
 import { getIndicatorMeta } from '../engine/indicators';
 import { magnitudeOf, delayLabelOf, magnitudeWeight } from '../engine/magnitudes';
+import { FACTIONS, reactionSymbol, type FactionId } from '../engine/factions';
+import AdvisorDebate from './AdvisorDebate';
 
 interface Props {
   event: GameEvent & { _model?: string };
   index: number;
   selectedChoice?: number;
   onChoose: (choiceIndex: number) => void;
+  onHoverChoice?: (choiceIndex: number | null) => void;
   aiMode?: boolean;
   onCustomResponse?: (text: string) => void;
   customResponseLoading?: boolean;
+  /** Turn number — used to seed deterministic advisor lines. */
+  turnSeed?: number;
 }
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -25,7 +30,7 @@ const CATEGORY_COLORS: Record<string, string> = {
   petition: '#6366f1',
 };
 
-export default function EventCard({ event, index, selectedChoice, onChoose, aiMode, onCustomResponse, customResponseLoading }: Props) {
+export default function EventCard({ event, index, selectedChoice, onChoose, onHoverChoice, aiMode, onCustomResponse, customResponseLoading, turnSeed = 0 }: Props) {
   const [customText, setCustomText] = useState('');
   const catColor = CATEGORY_COLORS[event.category] || '#94a3b8';
 
@@ -35,7 +40,7 @@ export default function EventCard({ event, index, selectedChoice, onChoose, aiMo
       <div className="flex items-start justify-between gap-3 mb-3">
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-1">
-            <span 
+            <span
               className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full"
               style={{ backgroundColor: `${catColor}20`, color: catColor }}
             >
@@ -44,6 +49,14 @@ export default function EventCard({ event, index, selectedChoice, onChoose, aiMo
             {event.oneTime && (
               <span className="text-[10px] text-slate-500 uppercase tracking-wider">One-time</span>
             )}
+            {event.highStakes && (
+              <span
+                className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded-full"
+                style={{ backgroundColor: 'rgba(184,134,11,0.15)', color: '#B8860B' }}
+              >
+                ⚡ High Stakes
+              </span>
+            )}
             {event._model && (
               <span className="text-[10px] px-1.5 py-0.5 rounded-full" style={{ backgroundColor: 'rgba(184,134,11,0.12)', color: '#B8860B' }}>✨ {event._model}</span>
             )}
@@ -51,11 +64,14 @@ export default function EventCard({ event, index, selectedChoice, onChoose, aiMo
           <h3 className="text-lg font-bold" style={{ color: '#1C1917' }}>{event.title}</h3>
         </div>
       </div>
-      
+
       <p className="text-sm leading-relaxed mb-1" style={{ color: '#3D3731' }}>{event.description}</p>
       {event.flavor && (
         <p className="text-xs italic mb-4" style={{ color: '#78716C' }}>{event.flavor}</p>
       )}
+
+      {/* Advisor Debate strip for high-stakes events */}
+      {event.highStakes && <AdvisorDebate event={event} seed={turnSeed + index} />}
 
       {/* Choices */}
       <div className="space-y-3 mt-4">
@@ -66,6 +82,12 @@ export default function EventCard({ event, index, selectedChoice, onChoose, aiMo
             <div
               key={ci}
               onClick={() => onChoose(ci)}
+              onMouseEnter={() => onHoverChoice?.(ci)}
+              onMouseLeave={() => onHoverChoice?.(null)}
+              onFocus={() => onHoverChoice?.(ci)}
+              onBlur={() => onHoverChoice?.(null)}
+              role="button"
+              tabIndex={0}
               className={`choice-card p-4 ${isSelected ? 'ring-2 ring-amber/40' : ''}`}
               style={isSelected ? { background: 'rgba(184,134,11,0.06)' } : undefined}
             >
@@ -122,6 +144,33 @@ export default function EventCard({ event, index, selectedChoice, onChoose, aiMo
                       </span>
                     )}
                   </div>
+
+                  {/* Faction reactions — show leader initials + emotion symbol */}
+                  {choice.factionReactions && Object.keys(choice.factionReactions).length > 0 && (
+                    <div className="flex flex-wrap items-center gap-1 mt-2 pt-2" style={{ borderTop: '1px dashed rgba(28,25,23,0.08)' }}>
+                      <span className="text-[9px] uppercase tracking-wider mr-1" style={{ color: '#9E3039' }}>Reactions:</span>
+                      {(Object.entries(choice.factionReactions) as [FactionId, 'love' | 'cheer' | 'meh' | 'frown' | 'rage'][]).map(([fid, level]) => {
+                        const f = FACTIONS.find(x => x.id === fid);
+                        if (!f) return null;
+                        return (
+                          <span
+                            key={fid}
+                            className="inline-flex items-center gap-0.5 text-[10px] px-1.5 py-0.5 rounded"
+                            style={{ background: `${f.color}18`, color: f.color }}
+                            title={`${f.leader} (${f.name}) — ${level}`}
+                          >
+                            <span
+                              className="inline-block w-4 h-4 rounded-full text-[8px] font-bold flex items-center justify-center"
+                              style={{ background: f.color, color: '#FFFFFF' }}
+                            >
+                              {f.leaderInitials}
+                            </span>
+                            <span>{reactionSymbol(level)}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                  )}
 
                   {/* Humor */}
                   {isSelected && choice.humor && (

--- a/src/ui/EventCard.tsx
+++ b/src/ui/EventCard.tsx
@@ -81,7 +81,14 @@ export default function EventCard({ event, index, selectedChoice, onChoose, onHo
           return (
             <div
               key={ci}
-              onClick={() => onChoose(ci)}
+              onClick={() => {
+                if (choice.irreversible && selectedChoice !== ci) {
+                  if (!window.confirm(`This decision is permanent.\n\n"${choice.label}"\n\nSome doors will close. Are you sure?`)) {
+                    return;
+                  }
+                }
+                onChoose(ci);
+              }}
               onMouseEnter={() => onHoverChoice?.(ci)}
               onMouseLeave={() => onHoverChoice?.(null)}
               onFocus={() => onHoverChoice?.(ci)}
@@ -89,7 +96,10 @@ export default function EventCard({ event, index, selectedChoice, onChoose, onHo
               role="button"
               tabIndex={0}
               className={`choice-card p-4 ${isSelected ? 'ring-2 ring-amber/40' : ''}`}
-              style={isSelected ? { background: 'rgba(184,134,11,0.06)' } : undefined}
+              style={{
+                ...(isSelected ? { background: 'rgba(184,134,11,0.06)' } : {}),
+                ...(choice.irreversible ? { borderLeft: '3px solid #DC2626' } : {}),
+              }}
             >
               <div className="flex items-start gap-3">
                 <div className={`w-6 h-6 rounded-full border-2 shrink-0 flex items-center justify-center mt-0.5 transition-all ${
@@ -98,7 +108,18 @@ export default function EventCard({ event, index, selectedChoice, onChoose, onHo
                   {isSelected && <span className="text-white text-xs font-bold">✓</span>}
                 </div>
                 <div className="flex-1">
-                  <h4 className="font-semibold text-sm mb-1" style={{ color: '#1C1917' }}>{choice.label}</h4>
+                  <div className="flex items-center gap-1.5 flex-wrap mb-1">
+                    <h4 className="font-semibold text-sm" style={{ color: '#1C1917' }}>{choice.label}</h4>
+                    {choice.irreversible && (
+                      <span
+                        className="text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded"
+                        style={{ background: '#DC2626', color: '#FFFFFF' }}
+                        title="This decision cannot be reversed in future quarters."
+                      >
+                        🔒 Permanent
+                      </span>
+                    )}
+                  </div>
                   <p className="text-xs leading-relaxed mb-2" style={{ color: '#78716C' }}>{choice.description}</p>
                   
                   {/* Effect preview — Reigns-style: direction + qualitative magnitude only */}

--- a/src/ui/EventCard.tsx
+++ b/src/ui/EventCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { GameEvent } from '../engine/types';
 import { getIndicatorMeta } from '../engine/indicators';
+import { magnitudeOf, delayLabelOf, magnitudeWeight } from '../engine/magnitudes';
 
 interface Props {
   event: GameEvent & { _model?: string };
@@ -78,30 +79,47 @@ export default function EventCard({ event, index, selectedChoice, onChoose, aiMo
                   <h4 className="font-semibold text-sm mb-1" style={{ color: '#1C1917' }}>{choice.label}</h4>
                   <p className="text-xs leading-relaxed mb-2" style={{ color: '#78716C' }}>{choice.description}</p>
                   
-                  {/* Effect preview */}
-                  <div className="flex flex-wrap gap-1.5">
+                  {/* Effect preview — Reigns-style: direction + qualitative magnitude only */}
+                  <div className="flex flex-wrap gap-1.5 items-center">
                     {choice.effects.slice(0, 5).map((eff, ei) => {
                       const meta = getIndicatorMeta(eff.indicator);
                       if (!meta) return null;
                       const isPositive = (meta.goodDirection === 'up' && eff.delta > 0) ||
                                         (meta.goodDirection === 'down' && eff.delta < 0);
                       const isNeutral = meta.goodDirection === 'neutral';
+                      const mag = magnitudeOf(eff.indicator, eff.delta);
+                      const delayLabel = delayLabelOf(eff.delay);
+                      const weight = magnitudeWeight(mag);
+                      const dots = '·'.repeat(weight);
                       return (
-                        <span 
-                          key={ei} 
-                          className={`text-[10px] px-1.5 py-0.5 rounded ${
+                        <span
+                          key={ei}
+                          className={`text-[10px] px-1.5 py-0.5 rounded inline-flex items-center gap-1 ${
                             isNeutral ? 'bg-blue-500/10 text-blue-600' :
                             isPositive ? 'bg-green-500/10 text-green-700' : 'bg-red-500/10 text-red-600'
                           }`}
-                          title={`${meta.name}: ${eff.delta > 0 ? '+' : ''}${eff.delta}${eff.delay > 0 ? ` (in ${eff.delay} turns)` : ''}`}
+                          title={`${meta.name} ${eff.delta > 0 ? '↑' : '↓'} ${mag}${delayLabel !== 'Now' ? ` · ${delayLabel}` : ''}`}
                         >
-                          {meta.emoji} {eff.delta > 0 ? '↑' : '↓'}
-                          {eff.delay > 0 && <span className="opacity-60 ml-0.5">⏳{eff.delay}t</span>}
+                          {meta.emoji}
+                          <span className="font-bold">{eff.delta > 0 ? '↑' : '↓'}</span>
+                          <span className="font-data leading-none tracking-tighter" aria-hidden="true">{dots}</span>
+                          {delayLabel !== 'Now' && (
+                            <span className="opacity-60">⏳</span>
+                          )}
                         </span>
                       );
                     })}
                     {choice.effects.length > 5 && (
                       <span className="text-[10px] text-slate-500">+{choice.effects.length - 5} more</span>
+                    )}
+                    {choice.hasEcho && (
+                      <span
+                        className="text-[10px] px-1.5 py-0.5 rounded inline-flex items-center gap-0.5 font-semibold"
+                        style={{ background: 'rgba(184,134,11,0.12)', color: '#B8860B' }}
+                        title="A delayed consequence will surface in a future quarter."
+                      >
+                        🔁 Echo expected
+                      </span>
                     )}
                   </div>
 

--- a/src/ui/FactionPulse.tsx
+++ b/src/ui/FactionPulse.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { FACTIONS, type FactionId, factionMood, factionMoodQuote } from '../engine/factions';
+
+interface Props {
+  approval: Record<FactionId, number>;
+  /** Optional reactions to a hovered choice — preview overlay. */
+  preview?: Partial<Record<FactionId, { delta: number; level: string; symbol: string }>>;
+}
+
+const MOOD_COLOR: Record<string, string> = {
+  love: '#16A34A',
+  happy: '#65A30D',
+  neutral: '#B8860B',
+  unhappy: '#EA580C',
+  crisis: '#DC2626',
+};
+
+export default function FactionPulse({ approval, preview }: Props) {
+  const [expandedId, setExpandedId] = useState<FactionId | null>(null);
+
+  return (
+    <div className="glass-card p-3 mb-3">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#9E3039' }}>
+          🎭 Faction Pulse
+        </h3>
+        <span className="text-[10px]" style={{ color: '#A8A29E' }}>tap a face to read the room</span>
+      </div>
+      <div className="grid grid-cols-7 gap-1 sm:gap-2">
+        {FACTIONS.map(f => {
+          const value = approval[f.id] ?? 50;
+          const previewEntry = preview?.[f.id];
+          const previewValue = previewEntry ? Math.max(0, Math.min(100, value + previewEntry.delta)) : null;
+          const mood = factionMood(value);
+          const moodColor = MOOD_COLOR[mood];
+          const isExpanded = expandedId === f.id;
+
+          return (
+            <button
+              key={f.id}
+              onClick={() => setExpandedId(isExpanded ? null : f.id)}
+              className="flex flex-col items-center group focus:outline-none"
+              aria-label={`${f.name}, led by ${f.leader}, ${mood}`}
+              title={`${f.name} — ${f.leader}`}
+            >
+              {/* Avatar */}
+              <div
+                className={`w-9 h-9 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-[11px] sm:text-xs font-bold mb-1 transition-all ${
+                  mood === 'crisis' ? 'faction-shake' : ''
+                } ${mood === 'love' ? 'faction-glow' : ''}`}
+                style={{
+                  background: f.color,
+                  color: '#FFFFFF',
+                  boxShadow: mood === 'crisis' ? '0 0 0 2px #DC2626' : mood === 'love' ? undefined : 'none',
+                  transform: previewEntry ? 'scale(1.05)' : undefined,
+                }}
+              >
+                {f.leaderInitials}
+              </div>
+              {/* Vertical bar */}
+              <div className="relative w-1.5 h-10 sm:h-12 rounded-full overflow-hidden" style={{ background: 'rgba(28,25,23,0.08)' }}>
+                <div
+                  className="absolute bottom-0 left-0 right-0 transition-all"
+                  style={{
+                    height: `${value}%`,
+                    background: moodColor,
+                  }}
+                />
+                {previewValue !== null && (
+                  <div
+                    className="absolute left-0 right-0 transition-all"
+                    style={{
+                      bottom: `${Math.min(value, previewValue)}%`,
+                      height: `${Math.abs(previewValue - value)}%`,
+                      background: previewEntry!.delta > 0 ? 'rgba(34,197,94,0.7)' : 'rgba(220,38,38,0.7)',
+                    }}
+                  />
+                )}
+              </div>
+              {previewEntry && (
+                <span className="text-xs mt-0.5">{previewEntry.symbol}</span>
+              )}
+              <span className="text-[9px] mt-0.5 font-mono tabular-nums" style={{ color: '#78716C' }}>
+                {Math.round(value)}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Expanded panel */}
+      {expandedId && (() => {
+        const f = FACTIONS.find(x => x.id === expandedId);
+        if (!f) return null;
+        const value = approval[f.id] ?? 50;
+        return (
+          <div className="mt-3 pt-3 fade-in" style={{ borderTop: '1px solid rgba(28,25,23,0.08)' }}>
+            <div className="flex items-start gap-3">
+              <div
+                className="w-12 h-12 rounded-full flex items-center justify-center text-sm font-bold shrink-0"
+                style={{ background: f.color, color: '#FFFFFF' }}
+              >
+                {f.leaderInitials}
+              </div>
+              <div className="flex-1 min-w-0">
+                <h4 className="text-sm font-bold" style={{ color: '#1C1917' }}>{f.name}</h4>
+                <p className="text-[11px]" style={{ color: '#78716C' }}>{f.leader} · {f.ideology}</p>
+                <p className="text-xs italic mt-1.5" style={{ color: '#3D3731' }}>
+                  {factionMoodQuote(f, value)}
+                </p>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/src/ui/GameOverScreen.tsx
+++ b/src/ui/GameOverScreen.tsx
@@ -1,6 +1,8 @@
 import { GameState } from '../engine/types';
 import { INDICATORS, getIndicatorMeta } from '../engine/indicators';
 import { createInitialState } from '../engine/state';
+import { generateLegacy } from '../engine/legacy';
+import { getTrait } from '../engine/traits';
 import FeedbackButton from './FeedbackButton';
 import BeatReality from './BeatReality';
 
@@ -21,6 +23,8 @@ function getGrade(score: number): { grade: string; title: string; description: s
 export default function GameOverScreen({ state, onRestart }: Props) {
   const grade = getGrade(state.score);
   const initial = createInitialState(state.seed);
+  const legacy = generateLegacy(state);
+  const traitDefs = state.traits.map(getTrait).filter(Boolean);
 
   // Calculate key changes
   const changes = INDICATORS.map(ind => ({
@@ -34,9 +38,52 @@ export default function GameOverScreen({ state, onRestart }: Props) {
   return (
     <div className="min-h-screen flex items-center justify-center p-4">
       <div className="max-w-2xl w-full fade-in">
+        {/* Legacy Report — Suzerain/Frostpunk-style verdict */}
+        <div
+          className="glass-card p-6 sm:p-8 mb-6 text-center"
+          style={{ background: 'linear-gradient(135deg, rgba(245,240,232,0.95), rgba(184,134,11,0.05))' }}
+        >
+          <div className="text-[10px] font-bold uppercase tracking-[0.25em] mb-3" style={{ color: '#B8860B' }}>
+            ── The Legacy Report ──
+          </div>
+          <div className="text-5xl mb-3">{legacy.archetype.emoji}</div>
+          <h2 className="text-2xl sm:text-3xl font-bold mb-3" style={{ color: '#1C1917' }}>
+            {legacy.archetype.label}
+          </h2>
+          {traitDefs.length > 0 && (
+            <div className="flex justify-center gap-2 mb-4 flex-wrap">
+              {traitDefs.map(t => t && (
+                <span key={t.id} className="text-[11px] px-2 py-0.5 rounded-full" style={{ background: 'rgba(184,134,11,0.12)', color: '#B8860B' }}>
+                  {t.emoji} {t.name}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="space-y-3 text-left">
+            {legacy.paragraphs.map((p, i) => (
+              <p key={i} className="text-sm leading-relaxed" style={{ color: '#3D3731' }}>{p}</p>
+            ))}
+          </div>
+          <div className="mt-5 pt-4 grid grid-cols-3 sm:grid-cols-6 gap-2" style={{ borderTop: '1px solid rgba(28,25,23,0.08)' }}>
+            {legacy.highlights.map(h => (
+              <div key={h.label} className="text-center">
+                <div
+                  className={`font-data text-sm sm:text-base font-bold ${
+                    h.tone === 'good' ? 'text-green-700' : h.tone === 'bad' ? 'text-red-600' : ''
+                  }`}
+                  style={{ color: h.tone === 'neutral' ? '#1C1917' : undefined }}
+                >
+                  {h.value}
+                </div>
+                <div className="text-[9px] uppercase tracking-wider" style={{ color: '#A8A29E' }}>{h.label}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
         <div className="glass-card p-8 text-center mb-6">
           <div className="text-6xl mb-4">{grade.emoji}</div>
-          
+
           <div className="inline-block px-6 py-2 rounded-xl mb-4" style={{
             background: '#9E3039',
           }}>
@@ -45,7 +92,7 @@ export default function GameOverScreen({ state, onRestart }: Props) {
 
           <h1 className="text-3xl font-bold mb-2" style={{ color: '#1C1917' }}>{grade.title}</h1>
           <p className="mb-4" style={{ color: '#78716C' }}>{grade.description}</p>
-          
+
           {state.gameOverReason && (
             <div className="glass-card p-4 text-left mb-6" style={{ borderColor: 'rgba(158,48,57,0.15)' }}>
               <p className="text-sm italic leading-relaxed" style={{ color: '#3D3731' }}>{state.gameOverReason}</p>

--- a/src/ui/GameScreen.tsx
+++ b/src/ui/GameScreen.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { GameState, GameEvent } from '../engine/types';
 import { getIndicatorMeta } from '../engine/indicators';
+import { magnitudeOf } from '../engine/magnitudes';
 import type { AIModel } from '../engine/ai';
 import IndicatorPanel from './IndicatorPanel';
 import EventCard from './EventCard';
@@ -150,11 +151,32 @@ export default function GameScreen({ state, events, decisions, onMakeChoice, onE
           )}
           <RatingsBar ratings={state.ratings} />
 
-          {/* Previous turn narrative */}
+          {/* Previous turn narrative + echoes + headlines */}
           {lastRecord && (
             <div className="glass-card p-4 fade-in">
               <h3 className="text-sm font-semibold mb-2 uppercase tracking-wider" style={{ color: '#B8860B' }}>📜 Last Quarter</h3>
               <p className="text-sm leading-relaxed" style={{ color: '#3D3731' }}>{lastRecord.narrative}</p>
+              {/* Echoes — delayed consequences from past decisions */}
+              {lastRecord.echoes && lastRecord.echoes.length > 0 && (
+                <div className="mt-3 pt-3 space-y-2" style={{ borderTop: '1px dashed rgba(184,134,11,0.25)' }}>
+                  <h4 className="text-[10px] font-bold uppercase tracking-wider" style={{ color: '#B8860B' }}>🔁 Echoes from earlier quarters</h4>
+                  {lastRecord.echoes.map((e, i) => (
+                    <p key={i} className="text-xs italic leading-relaxed" style={{ color: '#3D3731' }}>{e}</p>
+                  ))}
+                </div>
+              )}
+              {/* Headlines — Tropico-style commentary */}
+              {lastRecord.headlines && lastRecord.headlines.length > 0 && (
+                <div className="mt-3 pt-3 space-y-1" style={{ borderTop: '1px dashed rgba(158,48,57,0.18)' }}>
+                  <h4 className="text-[10px] font-bold uppercase tracking-wider" style={{ color: '#9E3039' }}>📰 The Morning Papers</h4>
+                  {lastRecord.headlines.map((h, i) => (
+                    <p key={i} className="text-xs leading-snug" style={{ color: '#3D3731' }}>
+                      <span className="font-semibold" style={{ color: '#9E3039' }}>{h.split(':')[0]}:</span>
+                      <span>{h.substring(h.indexOf(':') + 1)}</span>
+                    </p>
+                  ))}
+                </div>
+              )}
               {/* Show indicator changes */}
               <div className="mt-3 flex flex-wrap gap-2">
                 {Object.entries(lastRecord.indicatorsAfter).map(([key, val]) => {
@@ -166,13 +188,14 @@ export default function GameScreen({ state, events, decisions, onMakeChoice, onE
                   if (!meta) return null;
                   const isGood = (meta.goodDirection === 'up' && diff > 0) || 
                                  (meta.goodDirection === 'down' && diff < 0);
+                  const mag = magnitudeOf(key, diff);
                   return (
                     <span key={key} className={`text-xs px-2 py-1 rounded-full ${
                       isGood ? 'bg-green-500/10 text-green-600' : 
                       meta.goodDirection === 'neutral' ? 'bg-blue-500/10 text-blue-500' :
                       'bg-red-500/10 text-red-500'
                     }`}>
-                      {meta.emoji} {meta.name} {diff > 0 ? '↑' : '↓'}{Math.abs(diff).toFixed(1)}
+                      {meta.emoji} {meta.name} {diff > 0 ? '↑' : '↓'} {mag}
                     </span>
                   );
                 })}

--- a/src/ui/GameScreen.tsx
+++ b/src/ui/GameScreen.tsx
@@ -3,10 +3,14 @@ import { GameState, GameEvent } from '../engine/types';
 import { getIndicatorMeta } from '../engine/indicators';
 import { magnitudeOf } from '../engine/magnitudes';
 import { reactionDelta, reactionSymbol, type FactionId } from '../engine/factions';
+import type { PillarId } from '../engine/constitution';
 import type { AIModel } from '../engine/ai';
 import IndicatorPanel from './IndicatorPanel';
 import EventCard from './EventCard';
 import FactionPulse from './FactionPulse';
+import ConstitutionPanel from './ConstitutionPanel';
+import SuperpowerPanel from './SuperpowerPanel';
+import DecreesPanel from './DecreesPanel';
 import FeedbackButton from './FeedbackButton';
 import RatingsBar from './RatingsBar';
 import CoalitionBar from './CoalitionBar';
@@ -22,6 +26,10 @@ interface Props {
   decisions: Map<string, number>;
   onMakeChoice: (eventId: string, choiceIndex: number) => void;
   onEndTurn: () => void;
+  onAdvancePillar: (pillar: PillarId, direction: 1 | -1) => void;
+  onResolveDemand: (demandId: string, optionIdx: number) => void;
+  onEnactDecree: (decreeId: string) => void;
+  onRevokeDecree: (decreeId: string) => void;
   aiMode: boolean;
   onToggleAI: () => void;
   aiModels: AIModel[];
@@ -33,7 +41,7 @@ interface Props {
 
 const QUARTER_NAMES = ['Q1 Jan-Mar', 'Q2 Apr-Jun', 'Q3 Jul-Sep', 'Q4 Oct-Dec'];
 
-export default function GameScreen({ state, events, decisions, onMakeChoice, onEndTurn, aiMode, onToggleAI, aiModels, selectedModel, onSelectModel, onCustomResponse, aiLoading }: Props) {
+export default function GameScreen({ state, events, decisions, onMakeChoice, onEndTurn, onAdvancePillar, onResolveDemand, onEnactDecree, onRevokeDecree, aiMode, onToggleAI, aiModels, selectedModel, onSelectModel, onCustomResponse, aiLoading }: Props) {
   const allDecisionsMade = events.every(e => decisions.has(e.id));
   const lastRecord = state.history[state.history.length - 1];
   const [showIndicators, setShowIndicators] = useState(false);
@@ -155,6 +163,9 @@ export default function GameScreen({ state, events, decisions, onMakeChoice, onE
           {/* Coalition & Ratings */}
           <CoalitionBar parliament={state.parliament} currentTurn={state.turn} />
           <FactionPulse approval={state.factionApproval} preview={previewReactions} />
+          <SuperpowerPanel state={state} onResolve={onResolveDemand} />
+          <ConstitutionPanel state={state} onAdvance={onAdvancePillar} />
+          <DecreesPanel state={state} onEnact={onEnactDecree} onRevoke={onRevokeDecree} />
           {state.coalitionCrises && state.coalitionCrises.length > 0 && (
             <div className="glass-card p-4 fade-in" style={{ background: 'rgba(158,48,57,0.06)', border: '1px solid rgba(158,48,57,0.2)' }}>
               <h3 className="text-sm font-semibold mb-2 uppercase tracking-wider" style={{ color: '#9E3039' }}>

--- a/src/ui/GameScreen.tsx
+++ b/src/ui/GameScreen.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 import { GameState, GameEvent } from '../engine/types';
 import { getIndicatorMeta } from '../engine/indicators';
 import { magnitudeOf } from '../engine/magnitudes';
+import { reactionDelta, reactionSymbol, type FactionId } from '../engine/factions';
 import type { AIModel } from '../engine/ai';
 import IndicatorPanel from './IndicatorPanel';
 import EventCard from './EventCard';
+import FactionPulse from './FactionPulse';
 import FeedbackButton from './FeedbackButton';
 import RatingsBar from './RatingsBar';
 import CoalitionBar from './CoalitionBar';
@@ -35,8 +37,23 @@ export default function GameScreen({ state, events, decisions, onMakeChoice, onE
   const allDecisionsMade = events.every(e => decisions.has(e.id));
   const lastRecord = state.history[state.history.length - 1];
   const [showIndicators, setShowIndicators] = useState(false);
+  const [hoveredChoice, setHoveredChoice] = useState<{ eventId: string; choiceIndex: number } | null>(null);
   const termNumber = state.parliament.electionHistory.length + 1;
   const untilElection = turnsUntilElection(state);
+
+  // Compute preview reactions for the currently-hovered choice — used by FactionPulse.
+  const previewReactions: Partial<Record<FactionId, { delta: number; level: string; symbol: string }>> = (() => {
+    if (!hoveredChoice) return {};
+    const ev = events.find(e => e.id === hoveredChoice.eventId);
+    if (!ev) return {};
+    const ch = ev.choices[hoveredChoice.choiceIndex];
+    if (!ch?.factionReactions) return {};
+    const out: Partial<Record<FactionId, { delta: number; level: string; symbol: string }>> = {};
+    for (const [fid, level] of Object.entries(ch.factionReactions) as [FactionId, 'love' | 'cheer' | 'meh' | 'frown' | 'rage'][]) {
+      out[fid] = { delta: reactionDelta(level), level, symbol: reactionSymbol(level) };
+    }
+    return out;
+  })();
 
   return (
     <div className="min-h-screen p-2 sm:p-3 md:p-6 pb-24">
@@ -137,6 +154,7 @@ export default function GameScreen({ state, events, decisions, onMakeChoice, onE
         <main className="flex-1 space-y-3">
           {/* Coalition & Ratings */}
           <CoalitionBar parliament={state.parliament} currentTurn={state.turn} />
+          <FactionPulse approval={state.factionApproval} preview={previewReactions} />
           {state.coalitionCrises && state.coalitionCrises.length > 0 && (
             <div className="glass-card p-4 fade-in" style={{ background: 'rgba(158,48,57,0.06)', border: '1px solid rgba(158,48,57,0.2)' }}>
               <h3 className="text-sm font-semibold mb-2 uppercase tracking-wider" style={{ color: '#9E3039' }}>
@@ -215,9 +233,11 @@ export default function GameScreen({ state, events, decisions, onMakeChoice, onE
                 index={i}
                 selectedChoice={decisions.get(event.id)}
                 onChoose={(choiceIndex) => onMakeChoice(event.id, choiceIndex)}
+                onHoverChoice={(choiceIndex) => setHoveredChoice(choiceIndex === null ? null : { eventId: event.id, choiceIndex })}
                 aiMode={aiMode}
                 onCustomResponse={(text) => onCustomResponse(event.id, text)}
                 customResponseLoading={aiLoading}
+                turnSeed={state.turn}
               />
             ))}
           </div>

--- a/src/ui/ManifestoScreen.tsx
+++ b/src/ui/ManifestoScreen.tsx
@@ -1,0 +1,105 @@
+import { useState } from 'react';
+import { PROMISES, type PromiseDef } from '../engine/manifesto';
+
+interface Props {
+  onConfirm: (promiseIds: string[]) => void;
+  /** Term number — purely for display ("Promises for Term 1"). */
+  termNumber: number;
+  /** Optional: pre-selected promises from previous term to highlight as still-relevant. */
+  highlight?: string[];
+}
+
+const MAX_PROMISES = 3;
+
+export default function ManifestoScreen({ onConfirm, termNumber, highlight = [] }: Props) {
+  const [picked, setPicked] = useState<string[]>([]);
+
+  const toggle = (id: string) => {
+    setPicked(prev => {
+      if (prev.includes(id)) return prev.filter(x => x !== id);
+      if (prev.length >= MAX_PROMISES) return prev;
+      return [...prev, id];
+    });
+  };
+
+  const canConfirm = picked.length === MAX_PROMISES;
+
+  return (
+    <div className="min-h-screen p-4 sm:p-8">
+      <div className="max-w-3xl mx-auto fade-in">
+        <div className="text-center mb-6">
+          <div className="text-[10px] font-bold uppercase tracking-[0.25em] mb-2" style={{ color: '#B8860B' }}>
+            ── Campaign Promises · Term {termNumber} ──
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold mb-2" style={{ color: '#1C1917' }}>
+            What Will You <span style={{ color: '#9E3039' }}>Commit</span> To?
+          </h1>
+          <p className="text-sm sm:text-base max-w-xl mx-auto" style={{ color: '#78716C' }}>
+            Pick three. Break them, and voters remember — permanently. Keep them, and even your opposition will look briefly impressed.
+          </p>
+          <p className="text-xs mt-2" style={{ color: '#A8A29E' }}>
+            {picked.length}/{MAX_PROMISES} selected
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+          {PROMISES.map((p: PromiseDef) => {
+            const isPicked = picked.includes(p.id);
+            const isDisabled = !isPicked && picked.length >= MAX_PROMISES;
+            const isPrior = highlight.includes(p.id);
+            return (
+              <button
+                key={p.id}
+                onClick={() => toggle(p.id)}
+                disabled={isDisabled}
+                aria-pressed={isPicked}
+                className={`glass-card p-3 sm:p-4 text-left transition-all ${
+                  isPicked ? 'ring-2' : ''
+                } ${isDisabled ? 'opacity-40 cursor-not-allowed' : 'hover:scale-[1.01]'}`}
+                style={{
+                  background: isPicked ? 'rgba(184,134,11,0.08)' : isPrior ? 'rgba(158,48,57,0.04)' : undefined,
+                  boxShadow: isPicked ? '0 0 0 2px rgba(184,134,11,0.5)' : undefined,
+                  cursor: isDisabled ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <div className="flex items-start gap-2 mb-1">
+                  <h3 className="text-sm font-bold flex-1" style={{ color: '#1C1917' }}>{p.title}</h3>
+                  {isPicked && (
+                    <span className="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full" style={{ background: '#B8860B', color: '#FFFFFF' }}>
+                      Promised
+                    </span>
+                  )}
+                  {isPrior && !isPicked && (
+                    <span className="text-[10px] uppercase tracking-wider px-2 py-0.5 rounded-full" style={{ background: 'rgba(158,48,57,0.1)', color: '#9E3039' }}>
+                      Last term
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs leading-relaxed" style={{ color: '#78716C' }}>{p.description}</p>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="text-center">
+          <button
+            onClick={() => canConfirm && onConfirm(picked)}
+            disabled={!canConfirm}
+            className={`px-10 py-3 rounded-lg font-semibold text-base transition-all duration-200 ${
+              canConfirm ? 'pulse-amber' : 'opacity-40 cursor-not-allowed'
+            }`}
+            style={{
+              background: canConfirm ? '#9E3039' : 'rgba(28,25,23,0.08)',
+              color: canConfirm ? '#FFFFFF' : '#78716C',
+            }}
+          >
+            {canConfirm ? 'Sign the Manifesto →' : `Choose ${MAX_PROMISES - picked.length} more`}
+          </button>
+          <p className="text-[11px] mt-4 max-w-md mx-auto" style={{ color: '#A8A29E' }}>
+            Broken promises raise voter cynicism — a permanent malus on faction approval that grows with every term.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/OnboardingScreen.tsx
+++ b/src/ui/OnboardingScreen.tsx
@@ -1,0 +1,109 @@
+import { useState } from 'react';
+import { TRAIT_DEFS, type TraitId } from '../engine/traits';
+
+interface Props {
+  onConfirm: (traits: TraitId[]) => void;
+  onBack: () => void;
+}
+
+const MAX_PICKS = 2;
+
+export default function OnboardingScreen({ onConfirm, onBack }: Props) {
+  const [picked, setPicked] = useState<TraitId[]>([]);
+
+  const toggle = (id: TraitId) => {
+    setPicked(prev => {
+      if (prev.includes(id)) return prev.filter(x => x !== id);
+      if (prev.length >= MAX_PICKS) return prev;
+      return [...prev, id];
+    });
+  };
+
+  const canConfirm = picked.length === MAX_PICKS;
+
+  return (
+    <div className="min-h-screen p-4 sm:p-8">
+      <div className="max-w-3xl mx-auto fade-in">
+        <div className="text-center mb-6">
+          <div className="flex justify-center gap-0 mb-4">
+            <div className="w-12 h-1 rounded-full" style={{ background: '#9E3039' }} />
+            <div className="w-6 h-1 rounded-full mx-1" style={{ background: '#FFFFFF' }} />
+            <div className="w-12 h-1 rounded-full" style={{ background: '#9E3039' }} />
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold mb-2" style={{ color: '#1C1917' }}>
+            Who Are You, <span style={{ color: '#9E3039' }}>Premier?</span>
+          </h1>
+          <p className="text-sm sm:text-base" style={{ color: '#78716C' }}>
+            Pick two traits. They tilt your starting hand — and your reputation in Brussels, Moscow, and the Saeima cafeteria.
+          </p>
+          <p className="text-xs mt-2" style={{ color: '#A8A29E' }}>
+            {picked.length}/{MAX_PICKS} selected
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+          {TRAIT_DEFS.map(t => {
+            const isPicked = picked.includes(t.id);
+            const isDisabled = !isPicked && picked.length >= MAX_PICKS;
+            return (
+              <button
+                key={t.id}
+                onClick={() => toggle(t.id)}
+                disabled={isDisabled}
+                aria-pressed={isPicked}
+                className={`glass-card p-4 text-left transition-all ${
+                  isPicked ? 'ring-2' : ''
+                } ${isDisabled ? 'opacity-40 cursor-not-allowed' : 'hover:scale-[1.01]'}`}
+                style={{
+                  background: isPicked ? 'rgba(184,134,11,0.08)' : undefined,
+                  boxShadow: isPicked ? '0 0 0 2px rgba(184,134,11,0.5)' : undefined,
+                  cursor: isDisabled ? 'not-allowed' : 'pointer',
+                }}
+              >
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-2xl">{t.emoji}</span>
+                  <h3 className="text-lg font-bold" style={{ color: '#1C1917' }}>{t.name}</h3>
+                  {isPicked && (
+                    <span className="ml-auto text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full" style={{ background: '#B8860B', color: '#FFFFFF' }}>
+                      Picked
+                    </span>
+                  )}
+                </div>
+                <p className="text-xs italic mb-2" style={{ color: '#B8860B' }}>{t.tagline}</p>
+                <p className="text-xs leading-relaxed" style={{ color: '#3D3731' }}>{t.description}</p>
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-col sm:flex-row gap-3 justify-center items-center">
+          <button
+            onClick={onBack}
+            className="px-5 py-2.5 rounded-lg text-sm font-medium transition-all"
+            style={{ background: 'rgba(28,25,23,0.05)', color: '#78716C', border: '1px solid rgba(28,25,23,0.1)' }}
+          >
+            ← Back
+          </button>
+          <button
+            onClick={() => canConfirm && onConfirm(picked)}
+            disabled={!canConfirm}
+            className={`w-full sm:w-auto px-10 py-3 rounded-lg font-semibold text-base transition-all duration-200 ${
+              canConfirm ? 'pulse-amber' : 'opacity-40 cursor-not-allowed'
+            }`}
+            style={{
+              background: canConfirm ? '#9E3039' : 'rgba(28,25,23,0.08)',
+              color: canConfirm ? '#FFFFFF' : '#78716C',
+            }}
+          >
+            {canConfirm ? 'Take the Oath →' : `Pick ${MAX_PICKS - picked.length} more`}
+          </button>
+        </div>
+
+        <p className="text-center text-[11px] mt-6 max-w-md mx-auto" style={{ color: '#A8A29E' }}>
+          Traits are permanent for this run. You can pick a different combination next time —
+          and every combination unlocks slightly different paths through the quarters ahead.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/ui/SuperpowerPanel.tsx
+++ b/src/ui/SuperpowerPanel.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import type { GameState } from '../engine/types';
+import { SUPERPOWERS, getSuperpower, relationLabel, type Demand } from '../engine/superpowers';
+
+interface Props {
+  state: GameState;
+  onResolve: (demandId: string, optionIdx: number) => void;
+}
+
+export default function SuperpowerPanel({ state, onResolve }: Props) {
+  const [openDemandId, setOpenDemandId] = useState<string | null>(null);
+  const sp = state.superpowers;
+
+  return (
+    <div className="glass-card p-3 mb-3">
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wider" style={{ color: '#9E3039' }}>
+          🌍 The Powers
+        </h3>
+        {sp.active.length > 0 && (
+          <span className="text-[10px] font-bold px-2 py-0.5 rounded-full" style={{ background: '#9E3039', color: '#FFFFFF' }}>
+            {sp.active.length} active
+          </span>
+        )}
+      </div>
+
+      {/* Standing row */}
+      <div className="grid grid-cols-3 gap-2 mb-2">
+        {SUPERPOWERS.map(p => {
+          const value = sp.standing[p.id];
+          const label = relationLabel(value);
+          return (
+            <div key={p.id} className="rounded-lg p-1.5 text-center" style={{ background: 'rgba(28,25,23,0.03)' }}>
+              <div className="text-lg leading-none">{p.emoji}</div>
+              <div className="text-[10px] font-bold" style={{ color: p.color }}>{p.name}</div>
+              <div className="font-data text-[10px]" style={{ color: '#1C1917' }}>{Math.round(value)} · {label}</div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Active demands */}
+      {sp.active.length > 0 && (
+        <div className="space-y-1.5 mt-2">
+          {sp.active.map((d: Demand) => {
+            const isOpen = openDemandId === d.id;
+            const power = getSuperpower(d.power);
+            const turnsLeft = d.deadlineTurn - state.turn;
+            return (
+              <div key={d.id} className="rounded-lg" style={{ background: 'rgba(28,25,23,0.04)' }}>
+                <button
+                  onClick={() => setOpenDemandId(isOpen ? null : d.id)}
+                  className="w-full p-2 flex items-start gap-2 text-left"
+                >
+                  <span className="text-base">{power?.emoji}</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-xs font-semibold" style={{ color: '#1C1917' }}>{d.title}</div>
+                    <div className="text-[10px] mt-0.5" style={{ color: turnsLeft <= 1 ? '#DC2626' : '#78716C' }}>
+                      {turnsLeft <= 0 ? 'Deadline NOW' : `${turnsLeft} quarter${turnsLeft === 1 ? '' : 's'} to respond`}
+                    </div>
+                  </div>
+                  <span className="text-[10px]" style={{ color: '#A8A29E' }}>{isOpen ? '▲' : '▼'}</span>
+                </button>
+                {isOpen && (
+                  <div className="px-2 pb-2 fade-in">
+                    <p className="text-xs leading-relaxed mb-2" style={{ color: '#3D3731' }}>{d.body}</p>
+                    <div className="space-y-1">
+                      {d.options.map((opt, i) => (
+                        <button
+                          key={i}
+                          onClick={() => onResolve(d.id, i)}
+                          className="w-full text-left p-2 rounded-lg transition-all"
+                          style={{ background: 'rgba(255,255,255,0.6)', border: '1px solid rgba(28,25,23,0.06)' }}
+                        >
+                          <div className="text-[11px] font-semibold" style={{ color: '#1C1917' }}>{opt.label}</div>
+                          <div className="text-[10px]" style={{ color: '#78716C' }}>{opt.description}</div>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/constitution.test.ts
+++ b/tests/constitution.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  PILLARS,
+  createInitialConstitution,
+  canAdvancePillar,
+  advancePillar,
+  earnPoliticalCapital,
+} from '../src/engine/constitution';
+
+describe('constitution — Frostpunk Book of Laws', () => {
+  it('defines all 4 pillars with 5 steps each', () => {
+    expect(PILLARS.length).toBe(4);
+    for (const p of PILLARS) {
+      expect(Object.keys(p.steps).length).toBe(5); // -2..+2
+    }
+  });
+
+  it('starts at centre (0) on every pillar', () => {
+    const c = createInitialConstitution();
+    for (const p of PILLARS) {
+      expect(c.positions[p.id]).toBe(0);
+    }
+  });
+
+  it('canAdvancePillar refuses when out of capital', () => {
+    const c: ReturnType<typeof createInitialConstitution> = { ...createInitialConstitution(), politicalCapital: 0 };
+    const check = canAdvancePillar(c, 'economic', 1);
+    expect(check.ok).toBe(false);
+    expect(check.reason).toMatch(/Political Capital/);
+  });
+
+  it('canAdvancePillar refuses reversing direction', () => {
+    const c = createInitialConstitution();
+    const { next } = advancePillar({ ...c, politicalCapital: 50 }, 'economic', 1);
+    // After moving +1, going back -1 must be forbidden
+    const check = canAdvancePillar(next, 'economic', -1);
+    expect(check.ok).toBe(false);
+    expect(check.reason).toMatch(/not reversible/);
+  });
+
+  it('canAdvancePillar refuses going beyond ±2', () => {
+    let c: ReturnType<typeof createInitialConstitution> = { ...createInitialConstitution(), politicalCapital: 100 };
+    c = advancePillar(c, 'economic', 1).next;
+    c = advancePillar(c, 'economic', 1).next;
+    expect(c.positions.economic).toBe(2);
+    const check = canAdvancePillar(c, 'economic', 1);
+    expect(check.ok).toBe(false);
+  });
+
+  it('advancePillar decrements political capital by step cost', () => {
+    const c: ReturnType<typeof createInitialConstitution> = { ...createInitialConstitution(), politicalCapital: 20 };
+    const { next, step } = advancePillar(c, 'economic', 1);
+    expect(step).toBeTruthy();
+    expect(next.politicalCapital).toBeLessThan(c.politicalCapital);
+  });
+
+  it('advancePillar returns step effects so caller can apply them', () => {
+    const c: ReturnType<typeof createInitialConstitution> = { ...createInitialConstitution(), politicalCapital: 20 };
+    const { step } = advancePillar(c, 'economic', 1);
+    expect(step?.effects.length).toBeGreaterThan(0);
+  });
+
+  it('earnPoliticalCapital caps at 40', () => {
+    const c: ReturnType<typeof createInitialConstitution> = { ...createInitialConstitution(), politicalCapital: 39 };
+    const next = earnPoliticalCapital(c, 5);
+    expect(next.politicalCapital).toBe(40);
+  });
+});

--- a/tests/effects.test.ts
+++ b/tests/effects.test.ts
@@ -56,10 +56,23 @@ describe('effects — applyEffect', () => {
   it('applies immediate effect to indicator', () => {
     const state = makeState();
     const rng = createRng(42);
+    const effect: Effect = { indicator: 'gdp', delta: 5, delay: 0, duration: 0 };
+    const newState = applyEffect(state, effect, 'test', rng);
+    expect(newState.indicators.gdp).toBeGreaterThan(state.indicators.gdp);
+  });
+
+  it('bridges publicHappiness writes onto publicConfidence + socialStrain', () => {
+    const state = makeState();
+    const rng = createRng(42);
+    const before = {
+      conf: state.indicators.publicConfidence,
+      strain: state.indicators.socialStrain,
+    };
     const effect: Effect = { indicator: 'publicHappiness', delta: 5, delay: 0, duration: 0 };
     const newState = applyEffect(state, effect, 'test', rng);
-    // Delta is varied ±15%, so check it moved in the right direction
-    expect(newState.indicators.publicHappiness).toBeGreaterThan(state.indicators.publicHappiness);
+    // Confidence should go up, strain should go down.
+    expect(newState.indicators.publicConfidence).toBeGreaterThan(before.conf);
+    expect(newState.indicators.socialStrain).toBeLessThan(before.strain);
   });
 
   it('schedules delayed effect', () => {
@@ -75,14 +88,14 @@ describe('effects — applyEffect', () => {
     const state = makeState();
     const rng = createRng(42);
     const effect: Effect = {
-      indicator: 'publicHappiness',
+      indicator: 'gdp',
       delta: 10,
       delay: 0,
       duration: 0,
       condition: { indicator: 'gdp', op: '>', value: 1000 }, // impossible
     };
     const newState = applyEffect(state, effect, 'test', rng);
-    expect(newState.indicators.publicHappiness).toBe(state.indicators.publicHappiness);
+    expect(newState.indicators.gdp).toBe(state.indicators.gdp);
   });
 });
 
@@ -90,7 +103,7 @@ describe('effects — processScheduledEffects', () => {
   it('fires scheduled effects when turnsRemaining reaches 1', () => {
     const state = makeState({
       scheduledEffects: [{
-        indicator: 'publicHappiness',
+        indicator: 'gdp',
         delta: 5,
         turnsRemaining: 1,
         duration: 0,
@@ -99,7 +112,7 @@ describe('effects — processScheduledEffects', () => {
     });
     const rng = createRng(42);
     const newState = processScheduledEffects(state, rng);
-    expect(newState.indicators.publicHappiness).toBeGreaterThan(state.indicators.publicHappiness);
+    expect(newState.indicators.gdp).toBeGreaterThan(state.indicators.gdp);
     expect(newState.scheduledEffects.length).toBe(0);
   });
 

--- a/tests/factions.test.ts
+++ b/tests/factions.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import {
+  FACTIONS,
+  createInitialFactionApproval,
+  applyFactionReactions,
+  driftFactionApproval,
+  applyTraitFactionBias,
+  factionMood,
+  reactionDelta,
+} from '../src/engine/factions';
+import { createRng } from '../src/engine/random';
+
+describe('factions — Tropico-style ideological blocs', () => {
+  it('defines all 7 factions with required fields', () => {
+    expect(FACTIONS.length).toBe(7);
+    for (const f of FACTIONS) {
+      expect(f.id).toBeDefined();
+      expect(f.name).toBeTruthy();
+      expect(f.leader).toBeTruthy();
+      expect(f.leaderInitials.length).toBeGreaterThanOrEqual(2);
+      expect(f.praiseQuote).toBeTruthy();
+      expect(f.angerQuote).toBeTruthy();
+    }
+  });
+
+  it('createInitialFactionApproval seeds all factions to a value', () => {
+    const a = createInitialFactionApproval();
+    for (const f of FACTIONS) {
+      expect(typeof a[f.id]).toBe('number');
+    }
+  });
+
+  it('reactionDelta maps level to signed integer', () => {
+    expect(reactionDelta('love')).toBeGreaterThan(0);
+    expect(reactionDelta('rage')).toBeLessThan(0);
+    expect(reactionDelta('meh')).toBe(0);
+  });
+
+  it('applyFactionReactions shifts targeted factions only', () => {
+    const a = createInitialFactionApproval();
+    const rng = createRng(42);
+    const next = applyFactionReactions(a, { entrepreneurs: 'love' }, rng);
+    expect(next.entrepreneurs).toBeGreaterThan(a.entrepreneurs);
+    expect(next.socialDems).toBe(a.socialDems);
+  });
+
+  it('driftFactionApproval moves toward each faction\'s preferred indicators', () => {
+    const a = createInitialFactionApproval();
+    const rng = createRng(7);
+    const indicators: Record<string, number> = {
+      foreignInvestment: 90, techSector: 90, gdpGrowth: 6, portActivity: 90,
+      taxBurden: 20, corruptionLevel: 20,
+    };
+    const next = driftFactionApproval(a, indicators, rng);
+    // Entrepreneurs care about all of the above going the "right" way
+    expect(next.entrepreneurs).toBeGreaterThan(a.entrepreneurs);
+  });
+
+  it('applyTraitFactionBias shifts factions by trait map', () => {
+    const a = createInitialFactionApproval();
+    const next = applyTraitFactionBias(a, ['natoHawk']);
+    expect(next.natoBloc).toBeGreaterThan(a.natoBloc);
+    expect(next.minority).toBeLessThan(a.minority);
+  });
+
+  it('factionMood thresholds', () => {
+    expect(factionMood(80)).toBe('love');
+    expect(factionMood(60)).toBe('happy');
+    expect(factionMood(45)).toBe('neutral');
+    expect(factionMood(25)).toBe('unhappy');
+    expect(factionMood(10)).toBe('crisis');
+  });
+
+  it('cynicism drags drift downward', () => {
+    const a = createInitialFactionApproval();
+    const rng1 = createRng(99);
+    const rng2 = createRng(99);
+    const indicators = { foreignInvestment: 50 };
+    const noCynicism = driftFactionApproval(a, indicators, rng1, 0);
+    const highCynicism = driftFactionApproval(a, indicators, rng2, 30);
+    const sumNo = Object.values(noCynicism).reduce((s, v) => s + v, 0);
+    const sumHi = Object.values(highCynicism).reduce((s, v) => s + v, 0);
+    expect(sumHi).toBeLessThan(sumNo);
+  });
+});

--- a/tests/legacy.test.ts
+++ b/tests/legacy.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { generateLegacy, ARCHETYPES } from '../src/engine/legacy';
+import { createInitialState } from '../src/engine/state';
+
+describe('legacy — historian verdict at game end', () => {
+  it('returns one of the defined archetypes', () => {
+    const s = createInitialState(42);
+    const legacy = generateLegacy(s);
+    const ids = ARCHETYPES.map(a => a.id);
+    expect(ids).toContain(legacy.archetype.id);
+  });
+
+  it('produces multiple narrative paragraphs', () => {
+    const s = createInitialState(42);
+    const legacy = generateLegacy(s);
+    expect(legacy.paragraphs.length).toBeGreaterThanOrEqual(3);
+    for (const p of legacy.paragraphs) {
+      expect(p.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('high GDP + growth biases toward Baltic Tiger', () => {
+    const s = createInitialState(42);
+    s.indicators.gdp = 80;
+    s.indicators.gdpGrowth = 5;
+    s.indicators.foreignInvestment = 70;
+    s.indicators.techSector = 65;
+    s.indicators.publicDebt = 35;
+    const legacy = generateLegacy(s);
+    expect(legacy.archetype.id).toBe('balticTiger');
+  });
+
+  it('collapsed economy biases toward Lost Decade', () => {
+    const s = createInitialState(42);
+    s.indicators.gdp = 22;
+    s.indicators.population = 1.45;
+    s.indicators.publicDebt = 120;
+    s.indicators.publicConfidence = 15;
+    const legacy = generateLegacy(s);
+    expect(legacy.archetype.id).toBe('lostDecade');
+  });
+
+  it('returns 6 highlight stats', () => {
+    const s = createInitialState(42);
+    const legacy = generateLegacy(s);
+    expect(legacy.highlights.length).toBe(6);
+  });
+});

--- a/tests/magnitudes.test.ts
+++ b/tests/magnitudes.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { magnitudeOf, delayLabelOf, magnitudeWeight } from '../src/engine/magnitudes';
+
+describe('magnitudes — Reigns-style qualitative labels', () => {
+  it('classifies small deltas as Slight', () => {
+    // publicConfidence has range 100; 0.5 -> ~0.5% of range
+    expect(magnitudeOf('publicConfidence', 0.5)).toBe('Slight');
+  });
+
+  it('classifies mid deltas as Notable', () => {
+    expect(magnitudeOf('publicConfidence', 3)).toBe('Notable');
+  });
+
+  it('classifies large deltas as Major', () => {
+    expect(magnitudeOf('publicConfidence', 8)).toBe('Major');
+  });
+
+  it('classifies huge deltas as Severe', () => {
+    expect(magnitudeOf('publicConfidence', 25)).toBe('Severe');
+  });
+
+  it('calibrates by indicator range — GDP +3 still Notable on range 105', () => {
+    expect(magnitudeOf('gdp', 3)).toBe('Notable');
+  });
+
+  it('handles negative deltas the same as positive (absolute value)', () => {
+    expect(magnitudeOf('publicConfidence', -8)).toBe('Major');
+  });
+
+  it('delayLabelOf maps turns to qualitative words', () => {
+    expect(delayLabelOf(0)).toBe('Now');
+    expect(delayLabelOf(1)).toBe('Soon');
+    expect(delayLabelOf(4)).toBe('Later');
+    expect(delayLabelOf(8)).toBe('Long-term');
+  });
+
+  it('magnitudeWeight returns ascending weights', () => {
+    expect(magnitudeWeight('Slight')).toBe(1);
+    expect(magnitudeWeight('Notable')).toBe(2);
+    expect(magnitudeWeight('Major')).toBe(3);
+    expect(magnitudeWeight('Severe')).toBe(4);
+  });
+});

--- a/tests/newsfeed.test.ts
+++ b/tests/newsfeed.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { generateHeadlines } from '../src/engine/newsfeed';
+import { createInitialState } from '../src/engine/state';
+import { createRng } from '../src/engine/random';
+
+describe('newsfeed — procedural Tropico-style headlines', () => {
+  it('generates between 3 and 5 headlines per quarter', () => {
+    const state = createInitialState(123);
+    const before = { ...state.indicators };
+    const rng = createRng(7);
+    const headlines = generateHeadlines(state, [], before, rng);
+    expect(headlines.length).toBeGreaterThanOrEqual(3);
+    expect(headlines.length).toBeLessThanOrEqual(5);
+  });
+
+  it('every headline is prefixed with an outlet name', () => {
+    const state = createInitialState(99);
+    const headlines = generateHeadlines(state, [], { ...state.indicators }, createRng(11));
+    for (const h of headlines) {
+      expect(h).toContain(':');
+    }
+  });
+
+  it('reacts to economy movements', () => {
+    const state = createInitialState(42);
+    const before = { ...state.indicators };
+    state.indicators.gdp = state.indicators.gdp + 5;
+    state.indicators.foreignInvestment = state.indicators.foreignInvestment + 8;
+    const rng = createRng(3);
+    const headlines = generateHeadlines(state, [], before, rng);
+    // We expect at least one of the headlines to mention positive economy
+    const text = headlines.join('\n');
+    expect(text.length).toBeGreaterThan(20);
+  });
+
+  it('is deterministic for same seed', () => {
+    const state = createInitialState(11);
+    const before = { ...state.indicators };
+    const a = generateHeadlines(state, [], before, createRng(55));
+    const b = generateHeadlines(state, [], before, createRng(55));
+    expect(a).toEqual(b);
+  });
+});

--- a/tests/traits.test.ts
+++ b/tests/traits.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { applyTraitStartBias, applyTraitEffectModifiers, TRAIT_DEFS } from '../src/engine/traits';
+
+describe('traits — president onboarding picks', () => {
+  it('defines exactly 6 traits', () => {
+    expect(TRAIT_DEFS.length).toBe(6);
+  });
+
+  it('every trait has tagline + description', () => {
+    for (const t of TRAIT_DEFS) {
+      expect(t.tagline.length).toBeGreaterThan(5);
+      expect(t.description.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('applyTraitStartBias shifts indicators for known trait', () => {
+    const ind = { euStanding: 50, natoRelations: 50, nationalIdentity: 50, russiaRelations: 50 };
+    const next = applyTraitStartBias(ind, ['euroatlanticist']);
+    expect(next.euStanding).toBeGreaterThan(ind.euStanding);
+    expect(next.natoRelations).toBeGreaterThan(ind.natoRelations);
+  });
+
+  it('applyTraitEffectModifiers amplifies economy effects for Technocrat', () => {
+    const effect = { indicator: 'gdpGrowth', delta: 1, delay: 0, duration: 0 };
+    const modified = applyTraitEffectModifiers(effect, ['technocrat']);
+    expect(modified.delta).toBeGreaterThan(effect.delta);
+  });
+
+  it('applyTraitEffectModifiers stacks across multiple traits', () => {
+    const effect = { indicator: 'militaryReadiness', delta: 1, delay: 0, duration: 0 };
+    const onlyNato = applyTraitEffectModifiers(effect, ['natoHawk']);
+    const both = applyTraitEffectModifiers(effect, ['natoHawk', 'crisisManager']);
+    // Both should at least match NATO multiplier; crisisManager doesn't attenuate non-social
+    expect(both.delta).toBeGreaterThanOrEqual(onlyNato.delta * 0.999);
+  });
+});


### PR DESCRIPTION
## 🚨 Hotfix first

Production at https://amber.naurolabs.com/ is currently stuck on the loading spinner because of **React error #527** — `react@19.2.6` paired with `react-dom@19.2.5` (caret-range version skew across builds). This PR pins both packages to exact `19.2.5` and unblocks the site.

Verified locally with `npm run preview` + Playwright: title → onboarding → trait picker → manifesto all render cleanly.

---

## 🎮 The actual feature

Implements the full ""Make It Exciting"" plan — 15 PRs across 3 phases, designed to lift the game from ""policy spreadsheet"" to ""Tropico-grade simulation"" while staying event-card driven.

### Phase 1 — Quick wins (feel & character)
- **Hidden magnitudes** — Reigns-style. Cards show direction + qualitative label (Slight / Notable / Major / Severe). No exact deltas.
- **Confidence vs Strain** — dual society meter replaces single happiness. Frostpunk DNA. Existing `publicHappiness` writes are auto-bridged.
- **President traits** — pick 2 of 6 (Technocrat / Euro-Atlanticist / Populist / Crisis Manager / NATO Hawk / Baltic Pragmatist). Traits multiply effects + apply starting bias.
- **Delayed Echoes** — flagged choices fire a narrative micro-event 2-4 quarters later, referencing the source quarter.
- **Procedural Tropico newsfeed** — 60+ templated headlines across 9 outlet voices (Delfi, Dienas Bizness, Radio Juris, Brussels memo, Riga taxi driver, Dublin diaspora group chat, etc.).
- **Legacy Report** — Suzerain-style historian verdict at game end. One of 11 archetypes (Baltic Tiger, Brussels Technocrat, Lost Decade, The Coalition Whisperer, etc.) + multi-paragraph epilogue.

### Phase 2 — Characters & feedback loops
- **7 factions with named leaders** — Andris Kalniņš (Entrepreneurs), Ilze Krastiņa (Social Democrats), Gen. Ozoliņš (NATO Bloc), Dr. Vītola (Reform), Māris Bērziņš (National Identity), Elīna Ozola (Green Latvia), Sergejs Pavlovs (Russian-speaking minority). Each event choice tags faction reactions (love / cheer / meh / frown / rage).
- **FactionPulse UI** — 7-bar tension display. Crisis factions shake; loved factions glow. Hover a choice → preview where each bar would move.
- **Cabinet ministers + Advisor Debate** — 6 persistent minister NPCs with biases. Events flagged `highStakes` show 2-3 ministers arguing in character.
- **Manifesto promises + cynicism** — 3 promises from 9. Broken promises raise permanent cynicism, which drags faction approval.

### Phase 3 — Identity, stakes, geopolitics
- **Constitution Builder** — Frostpunk Book of Laws. 4 pillars × 5 positions. One-way ladder. Moves cost a new **Political Capital** resource that accrues each quarter.
- **5 Event Chain Arcs** — Rail Baltica Saga, Riga Housing Crisis, Brain Drain Spiral, Latgale Question, Energy Pivot.
- **EU / Russia / US superpower pressure** — Tropico Cold War mechanic mapped to Latvia's real geopolitics. Timed demand cards with deadlines.
- **Irreversibility flags** — choices marked `irreversible:true` render with a red border + permanent badge + confirmation modal.
- **12 Policy Decrees** — Tropico edicts. Toggleable persistent policies.

### Cross-cutting
- Tone bible enforced (Tropico-style Latvian deadpan)
- 107/107 tests pass (6 new test files)
- Lint clean · build green (502KB JS / 31KB CSS)

---

## 📊 Diff stats

37 files changed, 4611 insertions(+), 55 deletions(-).
13 new engine modules · 6 new UI screens · 6 new test files.

## ✅ Verification
- `npm run lint` → clean
- `npm run build` → green
- `npm test` → **107/107**
- `npm run preview` + Playwright run-through → title → onboarding → manifesto all render

## 🗺️ Try it
`npm run dev` → Title → Begin → pick 2 traits → pick 3 promises → Budget → Quarter 1

Reference games studied: Tropico 4–6, Suzerain, Frostpunk 1/2, Democracy 4, CK3, Reigns, Papers Please, This War of Mine.

---

🤖 Generated with [GitHub Copilot CLI](https://github.com/github/copilot-cli) (Claude Opus 4.7 / 1M context).
